### PR TITLE
Polish mobile task controls and preferences

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -188,6 +188,7 @@ export default class TodoistBoardPlugin extends Plugin {
   private todoistService!: TodoistService;
   private taskActions!: TaskActions;
   private stopTaskPolling?: () => void;
+  private settingsTab?: TodoistBoardSettingTab;
   private readonly taskPageSize = 100;
   private filterNextCursor: Record<string, string | null> = {};
   private taskHierarchy = new TaskHierarchy();
@@ -619,10 +620,12 @@ export default class TodoistBoardPlugin extends Plugin {
       if (!initialToken) {
         // console.warn("[Todoist Board] No Todoist API token found. Set one in the plugin settings.");
         // Still register the settings tab so the user can open settings even when not authenticated
-        this.addSettingTab(new TodoistBoardSettingTab(this.app, this));
+        this.settingsTab = new TodoistBoardSettingTab(this.app, this);
+        this.addSettingTab(this.settingsTab);
         return;
       }
-      this.addSettingTab(new TodoistBoardSettingTab(this.app, this));
+      this.settingsTab = new TodoistBoardSettingTab(this.app, this);
+      this.addSettingTab(this.settingsTab);
 
 
       if (!this.settings.filters?.some(f => f.isDefault)) {
@@ -1567,6 +1570,24 @@ export default class TodoistBoardPlugin extends Plugin {
     }
   }
 
+  private openAddTaskModalPreferences() {
+    this.closeModal();
+    this.settingsTab?.openPreferencesAddTaskModalSection();
+
+    const appWithSettings = this.app as typeof this.app & {
+      setting?: {
+        open?: () => void;
+        openTabById?: (id: string) => void;
+      };
+    };
+    appWithSettings.setting?.open?.();
+    appWithSettings.setting?.openTabById?.(this.manifest.id);
+
+    window.setTimeout(() => {
+      this.settingsTab?.openPreferencesAddTaskModalSection();
+    }, 80);
+  }
+
   private confirmDeleteTask(): Promise<boolean> {
     return new Promise((resolve) => {
       const modal = new Modal(this.app);
@@ -1791,6 +1812,8 @@ export default class TodoistBoardPlugin extends Plugin {
       submitLabel: "Add task",
       projects: this.projectCache,
       labels: this.labelCache,
+      visibleFields: this.settings.addTaskModal,
+      onOpenSettings: () => this.openAddTaskModalPreferences(),
       onSubmit: async ({ title, description, due, deadline, priority, projectId, labels }) => {
         try {
           await this.taskActions.addTask({
@@ -1830,6 +1853,7 @@ export default class TodoistBoardPlugin extends Plugin {
           modal.setForm({
             projects: this.projectCache,
             labels: this.labelCache,
+            visibleFields: this.settings.addTaskModal,
             fields: {
               title: "",
               description: "",
@@ -2966,6 +2990,12 @@ export default class TodoistBoardPlugin extends Plugin {
 
     const chinContainer = activeDocument.createElement("div");
     chinContainer.className = "chin-inner";
+    const primaryActions = activeDocument.createElement("div");
+    primaryActions.className = "chin-actions chin-actions-primary";
+    const secondaryActions = activeDocument.createElement("div");
+    secondaryActions.className = "chin-actions chin-actions-secondary";
+    chinContainer.appendChild(primaryActions);
+    chinContainer.appendChild(secondaryActions);
     const actions = Object.assign({}, DEFAULT_SETTINGS.chinBarActions, this.settings.chinBarActions || {});
     const getFilters = () => {
       let filters: string[] = [];
@@ -2982,13 +3012,14 @@ export default class TodoistBoardPlugin extends Plugin {
       iconName: string,
       label: string,
       onClick: (event: MouseEvent, button: HTMLButtonElement) => void,
+      container: HTMLElement = primaryActions,
     ) => {
       const button = activeDocument.createElement("button");
       button.className = `chin-btn ${className}`;
       setIcon(button, iconName);
       if (label) button.append(label);
       button.onclick = (event) => onClick(event, button);
-      chinContainer.appendChild(button);
+      container.appendChild(button);
       return button;
     };
 
@@ -3055,7 +3086,7 @@ export default class TodoistBoardPlugin extends Plugin {
             setIcon(hideBtn, "eye-off");
             hideBtn.title = "Unhide (undim)";
           }
-        });
+        }, secondaryActions);
         hideBtn.title = hidden.has(id) ? "Unhide (undim)" : "Hide (dim)";
         a11yButton(hideBtn, hideBtn.title);
       } catch {
@@ -3066,16 +3097,16 @@ export default class TodoistBoardPlugin extends Plugin {
     if (actions.deleteTask) {
       appendChinButton("delete-btn", "trash", "", () => {
         void this.deleteTask(task.id, apiKey, chinContainer);
-      });
+      }, secondaryActions);
     }
 
     if (actions.openInTodoist && task.url) {
       appendChinButton("open-todoist-btn", "external-link", "Open", () => {
         window.open(task.url, "_blank");
-      });
+      }, secondaryActions);
     }
 
-    if (!chinContainer.childElementCount) return;
+    if (!chinContainer.querySelector(".chin-btn")) return;
     wrapper.appendChild(chinContainer);
     row.appendChild(wrapper);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "todoist-board",
   "name": "Todoist Board",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "minAppVersion": "1.8.7",
   "description": "Display Todoist tasks as draggable cards with full sync support.",
   "author": "JD",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todoist-board",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todoist-board",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "dependencies": {
         "luxon": "^3.7.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-board",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Obsidian plugin for visualizing Todoist tasks",
   "repository": "https://github.com/propranolol11/todoist-board",
   "main": "main.js",

--- a/src/modals/task-sheet-modal.ts
+++ b/src/modals/task-sheet-modal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, setIcon } from "obsidian";
 import { TODOIST_COLORS, TODOIST_COLORS_NUM } from "../constants";
 import { clearEl } from "../dom";
-import type { Label, Project } from "../types";
+import type { AddTaskModalSettings, Label, Project } from "../types";
 
 export interface TaskModalFields {
   title?: string;
@@ -29,6 +29,8 @@ export interface TaskSheetModalOptions {
   submitLabel: string;
   projects: Project[];
   labels: Label[];
+  visibleFields?: Partial<AddTaskModalSettings>;
+  onOpenSettings?: () => void;
   onSubmit: (data: TaskModalSubmitData) => Promise<void> | void;
 }
 
@@ -95,6 +97,28 @@ export class TaskSheetModal extends Modal {
       event.preventDefault();
       this.lastTextInput?.focus();
     });
+  }
+
+  private restoreTextFocus(delay = 0) {
+    const input = this.lastTextInput;
+    if (!input) return;
+    window.setTimeout(() => input.focus(), delay);
+  }
+
+  private openDatePicker(input: HTMLInputElement) {
+    const dateInput = input as HTMLInputElement & { showPicker?: () => void };
+    if (typeof dateInput.showPicker === "function") {
+      try {
+        dateInput.showPicker();
+        this.restoreTextFocus();
+        return;
+      } catch {
+        // Fall back to a normal click for hosts that expose but reject showPicker.
+      }
+    }
+    input.click();
+    this.restoreTextFocus();
+    this.restoreTextFocus(250);
   }
 
   private renderForm() {
@@ -205,12 +229,20 @@ export class TaskSheetModal extends Modal {
 
   private createForm(): HTMLElement {
     const { fields, submitLabel, projects, labels } = this.options;
+    const visibleFields: AddTaskModalSettings = {
+      dueDate: true,
+      deadline: true,
+      priority: true,
+      project: true,
+      labels: true,
+      ...(this.options.visibleFields || {}),
+    };
     const ownerDocument = this.containerEl.ownerDocument;
     const wrapper = ownerDocument.createElement("div");
     wrapper.className = "taskmodal-wrapper";
 
     const formatDueText = (value: string) => {
-      if (!value) return "Due date";
+      if (!value) return "Date";
       const today = new Date();
       const todayIso = today.toISOString().slice(0, 10);
       if (value === todayIso) return "Today";
@@ -259,79 +291,105 @@ export class TaskSheetModal extends Modal {
 
     const chipRow = wrapper.createDiv({ cls: "taskmodal-chip-row" });
 
-    const dueAnchor = chipRow.createDiv({ cls: "taskmodal-date-anchor" });
+    const dueAnchor = visibleFields.dueDate
+      ? chipRow.createDiv({ cls: "taskmodal-date-anchor" })
+      : ownerDocument.createElement("div");
     const dueInput = dueAnchor.createEl("input", {
       cls: "taskmodal-date-input taskmodal-date-chip-native",
       type: "date",
       value: fields.due ?? "",
     });
 
-    const dueChip = dueAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-date-chip" });
-    dueChip.type = "button";
-    const dueIcon = dueChip.createSpan({ cls: "taskmodal-chip-icon" });
-    setIcon(dueIcon, "calendar");
-    const dueText = dueChip.createSpan({ cls: "taskmodal-chip-text" });
-    const dueClear = dueChip.createSpan({ cls: "taskmodal-chip-clear" });
-    setIcon(dueClear, "x");
+    if (visibleFields.dueDate) {
+      const dueChip = dueAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-date-chip" });
+      dueChip.type = "button";
+      const dueIcon = dueChip.createSpan({ cls: "taskmodal-chip-icon" });
+      setIcon(dueIcon, "calendar");
+      const dueText = dueChip.createSpan({ cls: "taskmodal-chip-text" });
+      const dueClear = dueChip.createSpan({ cls: "taskmodal-chip-clear" });
+      setIcon(dueClear, "x");
 
-    const syncDueChip = () => {
-      dueText.textContent = formatDueText(dueInput.value);
-      dueChip.classList.toggle("has-value", !!dueInput.value);
-      dueChip.setAttribute("aria-label", dueInput.value ? `Due ${dueText.textContent}` : "Set due date");
-    };
+      const syncDueChip = () => {
+        dueText.textContent = formatDueText(dueInput.value);
+        dueChip.classList.toggle("has-value", !!dueInput.value);
+        dueChip.setAttribute("aria-label", dueInput.value ? `Date ${dueText.textContent}` : "Set date");
+      };
 
-    dueChip.onclick = () => dueInput.click();
-    dueClear.onclick = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      dueInput.value = "";
+      this.keepKeyboardOnPointerDown(dueChip);
+      dueChip.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.openDatePicker(dueInput);
+      };
+      dueClear.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        dueInput.value = "";
+        syncDueChip();
+        this.lastTextInput?.focus();
+      };
+      this.keepKeyboardOnPointerDown(dueClear);
+      dueInput.addEventListener("change", syncDueChip);
       syncDueChip();
-      this.lastTextInput?.focus();
-    };
-    this.keepKeyboardOnPointerDown(dueClear);
-    dueInput.addEventListener("change", syncDueChip);
-    syncDueChip();
+    }
 
-    const deadlineAnchor = chipRow.createDiv({ cls: "taskmodal-date-anchor" });
+    const deadlineAnchor = visibleFields.deadline
+      ? chipRow.createDiv({ cls: "taskmodal-date-anchor" })
+      : ownerDocument.createElement("div");
     const deadlineInput = deadlineAnchor.createEl("input", {
       cls: "taskmodal-date-input taskmodal-deadline-chip-native",
       type: "date",
       value: fields.deadline ?? "",
     });
 
-    const deadlineChip = deadlineAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-deadline-chip" });
-    deadlineChip.type = "button";
-    const deadlineIcon = deadlineChip.createSpan({ cls: "taskmodal-chip-icon" });
-    setIcon(deadlineIcon, "target");
-    const deadlineText = deadlineChip.createSpan({ cls: "taskmodal-chip-text" });
-    const deadlineClear = deadlineChip.createSpan({ cls: "taskmodal-chip-clear" });
-    setIcon(deadlineClear, "x");
+    if (visibleFields.deadline) {
+      const deadlineChip = deadlineAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-deadline-chip" });
+      deadlineChip.type = "button";
+      const deadlineIcon = deadlineChip.createSpan({ cls: "taskmodal-chip-icon" });
+      setIcon(deadlineIcon, "target");
+      const deadlineText = deadlineChip.createSpan({ cls: "taskmodal-chip-text" });
+      const deadlineClear = deadlineChip.createSpan({ cls: "taskmodal-chip-clear" });
+      setIcon(deadlineClear, "x");
 
-    const syncDeadlineChip = () => {
-      deadlineText.textContent = formatDeadlineText(deadlineInput.value);
-      deadlineChip.classList.toggle("has-value", !!deadlineInput.value);
-      deadlineChip.setAttribute("aria-label", deadlineInput.value ? `Deadline ${deadlineText.textContent}` : "Set deadline");
-    };
+      const syncDeadlineChip = () => {
+        deadlineText.textContent = formatDeadlineText(deadlineInput.value);
+        deadlineChip.classList.toggle("has-value", !!deadlineInput.value);
+        deadlineChip.setAttribute("aria-label", deadlineInput.value ? `Deadline ${deadlineText.textContent}` : "Set deadline");
+      };
 
-    deadlineChip.onclick = () => deadlineInput.click();
-    deadlineClear.onclick = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      deadlineInput.value = "";
+      this.keepKeyboardOnPointerDown(deadlineChip);
+      deadlineChip.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.openDatePicker(deadlineInput);
+      };
+      deadlineClear.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        deadlineInput.value = "";
+        syncDeadlineChip();
+        this.lastTextInput?.focus();
+      };
+      this.keepKeyboardOnPointerDown(deadlineClear);
+      deadlineInput.addEventListener("change", syncDeadlineChip);
       syncDeadlineChip();
-      this.lastTextInput?.focus();
-    };
-    this.keepKeyboardOnPointerDown(deadlineClear);
-    deadlineInput.addEventListener("change", syncDeadlineChip);
-    syncDeadlineChip();
+    }
 
-    const priorityField = chipRow.createDiv({ cls: "taskmodal-priority-field" });
-    const priorityIcon = priorityField.createSpan({ cls: "taskmodal-chip-icon taskmodal-priority-icon" });
-    setIcon(priorityIcon, "flag");
-    const priorityButton = priorityField.createEl("button", { cls: "taskmodal-priority-button" });
+    const priorityField = visibleFields.priority
+      ? chipRow.createDiv({ cls: "taskmodal-priority-field" })
+      : ownerDocument.createElement("div");
+    if (visibleFields.priority) {
+      const priorityIcon = priorityField.createSpan({ cls: "taskmodal-chip-icon taskmodal-priority-icon" });
+      setIcon(priorityIcon, "flag");
+    }
+    const priorityButton = visibleFields.priority
+      ? priorityField.createEl("button", { cls: "taskmodal-priority-button" })
+      : ownerDocument.createElement("button");
     priorityButton.type = "button";
     const prioritySelect = priorityField.createEl("input", { cls: "taskmodal-priority-value", type: "hidden" });
-    const priorityMenu = priorityField.createDiv({ cls: "taskmodal-priority-menu" });
+    const priorityMenu = visibleFields.priority
+      ? priorityField.createDiv({ cls: "taskmodal-priority-menu" })
+      : ownerDocument.createElement("div");
     [
       { value: "1", label: "Priority" },
       { value: "4", label: "P1" },
@@ -355,35 +413,55 @@ export class TaskSheetModal extends Modal {
     });
     priorityField.setAttribute("data-priority", String(fields.priority ?? 1));
     prioritySelect.value = String(fields.priority ?? 1);
-    priorityButton.textContent = priorityLabel(Number(prioritySelect.value));
-    priorityButton.setAttribute("aria-label", priorityLabel(Number(prioritySelect.value)));
-    this.keepKeyboardOnPointerDown(priorityButton);
-    priorityButton.onclick = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      priorityMenu.classList.toggle("is-open");
-      this.lastTextInput?.focus();
-    };
+    if (visibleFields.priority) {
+      priorityButton.textContent = priorityLabel(Number(prioritySelect.value));
+      priorityButton.setAttribute("aria-label", priorityLabel(Number(prioritySelect.value)));
+      this.keepKeyboardOnPointerDown(priorityButton);
+      priorityButton.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        priorityMenu.classList.toggle("is-open");
+        this.lastTextInput?.focus();
+      };
+    }
 
-    const labelAnchor = chipRow.createDiv({ cls: "taskmodal-label-anchor" });
-    const labelButton = labelAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-label-chip" });
+    const labelAnchor = visibleFields.labels
+      ? chipRow.createDiv({ cls: "taskmodal-label-anchor" })
+      : ownerDocument.createElement("div");
+    const labelButton = visibleFields.labels
+      ? labelAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-label-chip" })
+      : ownerDocument.createElement("button");
     labelButton.type = "button";
-    this.keepKeyboardOnPointerDown(labelButton);
-    const labelButtonIcon = labelButton.createSpan({ cls: "taskmodal-chip-icon" });
-    setIcon(labelButtonIcon, "tag");
-    const labelButtonText = labelButton.createSpan({ cls: "taskmodal-chip-text" });
+    if (visibleFields.labels) {
+      this.keepKeyboardOnPointerDown(labelButton);
+    }
+    let labelButtonText: HTMLElement | null = null;
+    if (visibleFields.labels) {
+      const labelButtonIcon = labelButton.createSpan({ cls: "taskmodal-chip-icon" });
+      setIcon(labelButtonIcon, "tag");
+      labelButtonText = labelButton.createSpan({ cls: "taskmodal-chip-text" });
+    }
 
-    const labelPopover = labelAnchor.createDiv({ cls: "taskmodal-label-popover" });
-    const labelSearch = labelPopover.createEl("input", {
-      cls: "taskmodal-label-search",
-      type: "text",
-      placeholder: "Type a label",
-    });
-    const labelList = labelPopover.createDiv({ cls: "taskmodal-label-list" });
+    const labelPopover = visibleFields.labels
+      ? labelAnchor.createDiv({ cls: "taskmodal-label-popover" })
+      : ownerDocument.createElement("div");
+    const labelSearch = visibleFields.labels
+      ? labelPopover.createEl("input", {
+        cls: "taskmodal-label-search",
+        type: "text",
+        placeholder: "Type a label",
+      })
+      : ownerDocument.createElement("input");
+    const labelList = visibleFields.labels
+      ? labelPopover.createDiv({ cls: "taskmodal-label-list" })
+      : ownerDocument.createElement("div");
+    if (visibleFields.labels) {
+      this.rememberTextInput(labelSearch);
+    }
 
     const syncLabelChip = () => {
       const checked = Array.from(labelList.querySelectorAll<HTMLInputElement>("input[type='checkbox']:checked"));
-      labelButtonText.textContent = checked.length ? `Labels ${checked.length}` : "Labels";
+      if (labelButtonText) labelButtonText.textContent = checked.length ? `Labels ${checked.length}` : "Labels";
       labelButton.classList.toggle("has-value", checked.length > 0);
     };
 
@@ -400,27 +478,55 @@ export class TaskSheetModal extends Modal {
       labelCheckbox.createSpan({ cls: "taskmodal-label-option-name", text: label.name });
       const checkIcon = labelCheckbox.createSpan({ cls: "taskmodal-label-option-check" });
       setIcon(checkIcon, "check");
-      checkbox.addEventListener("change", () => {
+      const syncLabelOption = () => {
         labelCheckbox.classList.toggle("is-selected", checkbox.checked);
         syncLabelChip();
+        this.restoreTextFocus();
+      };
+      labelCheckbox.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        checkbox.checked = !checkbox.checked;
+        syncLabelOption();
+      };
+      checkbox.addEventListener("change", () => {
+        syncLabelOption();
       });
     }
     syncLabelChip();
 
-    labelButton.onclick = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      labelAnchor.classList.toggle("is-open");
-      this.lastTextInput?.focus();
-    };
-    labelPopover.addEventListener("click", (event) => event.stopPropagation());
-    labelSearch.addEventListener("input", () => {
-      const query = labelSearch.value.trim().toLowerCase();
-      labelList.querySelectorAll<HTMLElement>(".taskmodal-label-option").forEach((option) => {
-        const name = option.querySelector<HTMLElement>(".taskmodal-label-option-name")?.textContent || "";
-        option.classList.toggle("tb-hidden", !!query && !name.toLowerCase().includes(query));
+    if (visibleFields.labels) {
+      labelButton.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        labelAnchor.classList.toggle("is-open");
+        this.lastTextInput?.focus();
+      };
+      labelPopover.addEventListener("click", (event) => event.stopPropagation());
+      labelSearch.addEventListener("input", () => {
+        const query = labelSearch.value.trim().toLowerCase();
+        labelList.querySelectorAll<HTMLElement>(".taskmodal-label-option").forEach((option) => {
+          const name = option.querySelector<HTMLElement>(".taskmodal-label-option-name")?.textContent || "";
+          option.classList.toggle("tb-hidden", !!query && !name.toLowerCase().includes(query));
+        });
       });
-    });
+    }
+
+    if (this.options.onOpenSettings) {
+      const settingsButton = chipRow.createEl("button", {
+        cls: "taskmodal-chip taskmodal-more-settings-button",
+        text: "...",
+        type: "button",
+      });
+      settingsButton.setAttribute("aria-label", "Edit add task modal fields");
+      settingsButton.title = "Edit add task modal fields";
+      this.keepKeyboardOnPointerDown(settingsButton);
+      settingsButton.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.options.onOpenSettings?.();
+      };
+    }
 
     wrapper.addEventListener("click", (event) => {
       if (!(event.target as HTMLElement).closest(".taskmodal-label-anchor")) {
@@ -432,13 +538,19 @@ export class TaskSheetModal extends Modal {
     });
 
     const footerRow = wrapper.createDiv({ cls: "taskmodal-footer-row" });
-    const projectField = footerRow.createDiv({ cls: "taskmodal-project-field" });
-    const projectIcon = projectField.createSpan({ cls: "taskmodal-footer-icon" });
-    setIcon(projectIcon, "inbox");
-    const projectVisible = projectField.createDiv({ cls: "taskmodal-project-visible" });
-    const projectName = projectVisible.createSpan({ cls: "taskmodal-project-name" });
-    const projectChevron = projectVisible.createSpan({ cls: "taskmodal-project-chevron" });
-    setIcon(projectChevron, "chevron-down");
+    const projectField = visibleFields.project
+      ? footerRow.createDiv({ cls: "taskmodal-project-field" })
+      : ownerDocument.createElement("div");
+    let projectIcon: HTMLElement | null = null;
+    let projectName: HTMLElement | null = null;
+    if (visibleFields.project) {
+      projectIcon = projectField.createSpan({ cls: "taskmodal-footer-icon" });
+      setIcon(projectIcon, "inbox");
+      const projectVisible = projectField.createDiv({ cls: "taskmodal-project-visible" });
+      projectName = projectVisible.createSpan({ cls: "taskmodal-project-name" });
+      const projectChevron = projectVisible.createSpan({ cls: "taskmodal-project-chevron" });
+      setIcon(projectChevron, "chevron-down");
+    }
     const projectSelect = projectField.createEl("select", { cls: "taskmodal-project-select" });
     for (const project of Array.isArray(projects) ? projects : []) {
       const option = ownerDocument.createElement("option");
@@ -451,8 +563,8 @@ export class TaskSheetModal extends Modal {
     }
     const syncProjectChrome = () => {
       const selectedName = projectSelect.selectedOptions[0]?.textContent || "";
-      projectName.textContent = selectedName || "Inbox";
-      projectIcon.classList.toggle("tb-hidden", selectedName.trim().toLowerCase() !== "inbox");
+      if (projectName) projectName.textContent = selectedName || "Inbox";
+      projectIcon?.classList.toggle("tb-hidden", selectedName.trim().toLowerCase() !== "inbox");
     };
     projectSelect.addEventListener("change", syncProjectChrome);
     syncProjectChrome();

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,8 +1,9 @@
 import { App, Notice, Plugin, PluginSettingTab, Setting, setIcon } from "obsidian";
 import { COMMON_TIMEZONES } from "./settings";
-import type { ChinBarSettings, ContextMenuSettings, TodoistBoardSettings } from "./types";
+import type { AddTaskModalSettings, ChinBarSettings, ContextMenuSettings, TodoistBoardSettings } from "./types";
 
-type SettingsTabId = "getting-started" | "behavior" | "actions" | "support";
+type SettingsTabId = "getting-started" | "preferences" | "advanced" | "support";
+type SettingsFocusTarget = "add-task-modal";
 
 export interface TodoistSettingsPlugin {
   settings: TodoistBoardSettings;
@@ -13,6 +14,7 @@ export interface TodoistSettingsPlugin {
 
 export class TodoistBoardSettingTab extends PluginSettingTab {
   private activeTab: SettingsTabId = "getting-started";
+  private pendingFocusTarget: SettingsFocusTarget | null = null;
 
   constructor(app: App, readonly plugin: Plugin & TodoistSettingsPlugin) {
     super(app, plugin);
@@ -30,8 +32,8 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
 
     const tabs: Array<{ id: SettingsTabId; label: string; icon: string }> = [
       { id: "getting-started", label: "Start", icon: "sparkles" },
-      { id: "behavior", label: "Behavior", icon: "sliders-horizontal" },
-      { id: "actions", label: "Actions", icon: "mouse-pointer-click" },
+      { id: "preferences", label: "Preferences", icon: "mouse-pointer-click" },
+      { id: "advanced", label: "Advanced", icon: "sliders-horizontal" },
       { id: "support", label: "Support", icon: "heart" },
     ];
 
@@ -51,13 +53,19 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
 
     if (this.activeTab === "getting-started") {
       this.renderGettingStarted(content, pluginSettings);
-    } else if (this.activeTab === "behavior") {
-      this.renderBehavior(content, pluginSettings);
-    } else if (this.activeTab === "actions") {
-      this.renderActions(content, pluginSettings);
+    } else if (this.activeTab === "preferences") {
+      this.renderPreferences(content, pluginSettings);
+    } else if (this.activeTab === "advanced") {
+      this.renderAdvanced(content, pluginSettings);
     } else {
       this.renderSupport(content);
     }
+  }
+
+  public openPreferencesAddTaskModalSection() {
+    this.activeTab = "preferences";
+    this.pendingFocusTarget = "add-task-modal";
+    this.display();
   }
 
   private renderGettingStarted(container: HTMLElement, pluginSettings: TodoistBoardSettings) {
@@ -127,15 +135,15 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
     this.createExternalLink(repoItem, "GitHub", "https://github.com/propranolol11/todoist-board", "github");
   }
 
-  private renderBehavior(container: HTMLElement, pluginSettings: TodoistBoardSettings) {
+  private renderAdvanced(container: HTMLElement, pluginSettings: TodoistBoardSettings) {
     this.renderPanelHeader(
       container,
-      "Behavior",
+      "Advanced",
       "Tune logging and date handling for this vault.",
     );
 
-    const behaviorCard = container.createDiv({ cls: "todoist-settings-card" });
-    new Setting(behaviorCard)
+    const advancedCard = container.createDiv({ cls: "todoist-settings-card" });
+    new Setting(advancedCard)
       .setName("Console logging")
       .setDesc("Print debug output of Todoist Board to the developer console.")
       .addToggle((toggle) => {
@@ -148,7 +156,7 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
           });
       });
 
-    new Setting(behaviorCard)
+    new Setting(advancedCard)
       .setName("Timezone mode")
       .setDesc("Choose how timezone is determined for your tasks.")
       .addDropdown((dropdown) =>
@@ -164,7 +172,7 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
       );
 
     if (pluginSettings.timezoneMode === "manual") {
-      new Setting(behaviorCard)
+      new Setting(advancedCard)
         .setName("Manual timezone")
         .setDesc("Overrides system timezone if 'manual' mode is selected above")
         .addDropdown((dropdown) => {
@@ -179,11 +187,11 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
     }
   }
 
-  private renderActions(container: HTMLElement, pluginSettings: TodoistBoardSettings) {
+  private renderPreferences(container: HTMLElement, pluginSettings: TodoistBoardSettings) {
     this.renderPanelHeader(
       container,
-      "Task Actions",
-      "Choose which actions appear when you right-click a task.",
+      "Preferences",
+      "Choose which task controls are shown throughout Todoist Board.",
     );
 
     const contextMenuSection = container.createDiv({ cls: "settings-context-preview-section" });
@@ -300,6 +308,72 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
         })();
       });
     });
+
+    const addTaskSection = container.createDiv({ cls: "settings-chin-preview-section" });
+    addTaskSection.dataset.settingsSection = "add-task-modal";
+    this.renderHeading(addTaskSection, "Add task modal", "settings-context-preview-title");
+    addTaskSection.createEl("p", {
+      cls: "settings-context-preview-desc",
+      text: "User friendly controls for showing or hiding optional fields in the Add Task modal.",
+    });
+
+    const addTaskActions: Array<{ key: keyof AddTaskModalSettings; label: string; icon: string }> = [
+      { key: "dueDate", label: "Date", icon: "calendar" },
+      { key: "deadline", label: "Deadline", icon: "target" },
+      { key: "priority", label: "Priority", icon: "flag" },
+      { key: "project", label: "Project", icon: "inbox" },
+      { key: "labels", label: "Labels", icon: "tag" },
+    ];
+    const previewAddTask = addTaskSection.createDiv({ cls: "settings-chin-preview settings-add-task-preview" });
+    const ensureAddTaskModal = (): AddTaskModalSettings => {
+      if (!pluginSettings.addTaskModal) {
+        pluginSettings.addTaskModal = {} as AddTaskModalSettings;
+      }
+      return pluginSettings.addTaskModal;
+    };
+    const addTaskControlIsEnabled = (key: keyof AddTaskModalSettings): boolean =>
+      pluginSettings.addTaskModal?.[key] ?? true;
+
+    addTaskActions.forEach((action) => {
+      const actionButton = previewAddTask.createEl("button", {
+        cls: "settings-chin-action",
+        type: "button",
+      });
+      const icon = actionButton.createSpan({ cls: "settings-chin-action-icon" });
+      setIcon(icon, action.icon);
+      actionButton.createSpan({ text: action.label });
+
+      const syncActionButton = () => {
+        const enabled = addTaskControlIsEnabled(action.key);
+        actionButton.classList.toggle("is-enabled", enabled);
+        actionButton.setAttribute("aria-pressed", String(enabled));
+        actionButton.setAttribute("aria-label", `${enabled ? "Hide" : "Show"} ${action.label}`);
+      };
+
+      syncActionButton();
+      actionButton.addEventListener("click", () => {
+        void (async () => {
+        const addTaskModal = ensureAddTaskModal();
+        addTaskModal[action.key] = !addTaskControlIsEnabled(action.key);
+        syncActionButton();
+        await this.plugin.saveSettings();
+        })();
+      });
+    });
+
+    this.focusSectionIfPending("add-task-modal", addTaskSection);
+  }
+
+  private focusSectionIfPending(target: SettingsFocusTarget, element: HTMLElement) {
+    if (this.pendingFocusTarget !== target) return;
+    window.requestAnimationFrame(() => {
+      element.scrollIntoView({ block: "start", behavior: "smooth" });
+      element.classList.add("is-settings-focus-target");
+      window.setTimeout(() => {
+        element.classList.remove("is-settings-focus-target");
+      }, 1400);
+    });
+    this.pendingFocusTarget = null;
   }
 
   private renderSupport(container: HTMLElement) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -128,6 +128,13 @@ export const DEFAULT_SETTINGS: TodoistBoardSettings = {
     setDeadline: false,
     openInTodoist: false,
   },
+  addTaskModal: {
+    dueDate: true,
+    deadline: true,
+    priority: true,
+    project: true,
+    labels: true,
+  },
 };
 
 export function normalizeSettings(saved: Partial<TodoistBoardSettings> | null | undefined): TodoistBoardSettings {
@@ -147,6 +154,11 @@ export function normalizeSettings(saved: Partial<TodoistBoardSettings> | null | 
     {},
     DEFAULT_SETTINGS.chinBarActions,
     merged.chinBarActions || {},
+  );
+  merged.addTaskModal = Object.assign(
+    {},
+    DEFAULT_SETTINGS.addTaskModal,
+    merged.addTaskModal || {},
   );
   return merged;
 }

--- a/src/task-rendering.ts
+++ b/src/task-rendering.ts
@@ -1,4 +1,4 @@
-import { MarkdownRenderer } from "obsidian";
+import { MarkdownRenderer, setIcon } from "obsidian";
 import { DateTime } from "luxon";
 import { TODOIST_COLORS, TODOIST_COLORS_NUM } from "./constants";
 import { clearEl } from "./dom";
@@ -68,8 +68,48 @@ export function createTaskContent(options: TaskContentRenderOptions): HTMLElemen
   descEl.className = "task-description";
   if (typeof task.description === "string" && task.description.trim()) {
     descEl.textContent = task.description;
+    descEl.classList.add("has-description", "desc-collapsed");
+    const toggleDescription = activeDocument.createElement("button");
+    toggleDescription.className = "task-description-toggle";
+    toggleDescription.type = "button";
+    toggleDescription.setAttribute("aria-label", "Expand description");
+    toggleDescription.setAttribute("aria-expanded", "false");
+    setIcon(toggleDescription, "chevron-down");
+    const syncDescriptionToggle = (expanded: boolean) => {
+      descEl.classList.toggle("desc-expanded", expanded);
+      descEl.classList.toggle("desc-collapsed", !expanded);
+      toggleDescription.setAttribute("aria-expanded", String(expanded));
+      toggleDescription.setAttribute("aria-label", expanded ? "Collapse description" : "Expand description");
+      setIcon(toggleDescription, expanded ? "chevron-up" : "chevron-down");
+    };
+    const toggleExpandedDescription = () => {
+      const expanded = !descEl.classList.contains("desc-expanded");
+      syncDescriptionToggle(expanded);
+    };
+    let toggledFromTouchPointer = false;
+    toggleDescription.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+    toggleDescription.addEventListener("pointerup", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.pointerType === "touch" || event.pointerType === "pen") {
+        toggledFromTouchPointer = true;
+        toggleExpandedDescription();
+        window.setTimeout(() => {
+          toggledFromTouchPointer = false;
+        }, 0);
+      }
+    });
+    toggleDescription.onclick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (toggledFromTouchPointer) return;
+      toggleExpandedDescription();
+    };
+    descEl.appendChild(toggleDescription);
   } else {
-    descEl.textContent = " ";
     descEl.classList.add("desc-empty");
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,14 @@ export interface ChinBarSettings {
   openInTodoist: boolean;
 }
 
+export interface AddTaskModalSettings {
+  dueDate: boolean;
+  deadline: boolean;
+  priority: boolean;
+  project: boolean;
+  labels: boolean;
+}
+
 export interface TodoistBoardSettings {
   apiKey: string;
   filters?: Filter[];
@@ -146,6 +154,7 @@ export interface TodoistBoardSettings {
   enableLogs?: boolean;
   contextMenuActions?: ContextMenuSettings;
   chinBarActions?: ChinBarSettings;
+  addTaskModal?: AddTaskModalSettings;
 }
 
 export interface TodoistMetadata {

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,8 @@
   --pill-text: #4b5563;
   --selected-bg: #f6f9ff;
   --selected-border: #b4cef5;
+  --selected-card-radius: 12px;
+  --chin-button-radius: calc(var(--selected-card-radius) - 2px);
   --deadline-bg: #d8d5ff;
   --deadline-text: #6b21a8;
   --meta-text: #6b7280;
@@ -587,7 +589,7 @@ body.theme-dark .todoist-board .task-title {
     rgba(6, 24, 44, 0.4) 0px 0px 0px 0.1px,
     rgba(6, 24, 44, 0.65) 0px 4px 4px -3px,
     rgba(255, 255, 255, 0.08) -3px 1px 0px 0px;
-  border-radius: 12px;
+  border-radius: var(--selected-card-radius);
   border: 1px solid #e5e7eb;
   margin-block-start: 1rem;
   margin-block-end: 0.75rem;
@@ -639,6 +641,59 @@ body.tb-has-selected-task .todoist-board .task:not(.selected-task):not(.subtask-
   position: relative;
 }
 
+.todoist-board .selected-task.has-fixed-chin {
+  display: block;
+  overflow: hidden;
+  padding: 0;
+}
+
+.todoist-board .selected-task.has-fixed-chin > input.todoist-checkbox {
+  left: 14px;
+  margin: 0;
+  position: absolute;
+  top: 14px;
+}
+
+.todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper {
+  display: block;
+  flex: 0 0 auto;
+  height: auto;
+  max-height: none;
+  min-height: 0;
+  overflow: visible;
+  padding: 0;
+  width: 100%;
+}
+
+.todoist-board .selected-task > .task-scroll-wrapper > .fixed-chin {
+  display: none;
+  margin: 0;
+  padding: 0;
+}
+
+.todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner,
+.todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner > .task-content,
+.todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner .task-content-wrapper {
+  display: block;
+  flex: 0 0 auto;
+  height: auto;
+  max-height: none;
+  min-height: 0;
+  min-width: 0;
+  overflow: visible;
+  width: 100%;
+}
+
+.todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner {
+  min-height: 0;
+  padding: 12px 12px 8px 54px;
+}
+
+.todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner .task-content-wrapper {
+  flex: 0 0 auto;
+  padding-bottom: 0;
+}
+
 .todoist-board .selected-task .task-inner {
   flex: 0 0 auto;
   min-width: 0;
@@ -659,7 +714,7 @@ body.tb-has-selected-task .todoist-board .task:not(.selected-task):not(.subtask-
   justify-content: flex-start;
   flex-direction: column;
   align-items: stretch;
-  height: 100%;
+  height: auto;
   min-height: unset;
   min-width: 0;
   max-width: 100%;
@@ -942,10 +997,15 @@ input.todoist-checkbox::after {
 
 /* Restrict height and allow scrolling for long descriptions in selected task */
 .todoist-board .selected-task .task-description {
-  max-height: 80px;
+  max-height: 112px;
   padding-bottom: 0.5rem;
   overflow-y: auto;
   position: relative;
+}
+
+.todoist-board .selected-task .task-description.desc-expanded {
+  max-height: none;
+  overflow: visible;
 }
 
 
@@ -1049,6 +1109,45 @@ input.todoist-checkbox::after {
   white-space: pre-line;
 }
 
+.todoist-board .task-description-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  bottom: 0;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  height: 22px;
+  justify-content: center;
+  opacity: 0;
+  padding: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+  width: 22px;
+}
+
+.todoist-board .task-description-toggle svg {
+  height: 16px;
+  width: 16px;
+}
+
+.todoist-board .selected-task .task-description.has-description:hover .task-description-toggle,
+.todoist-board .selected-task .task-description.has-description:focus-within .task-description-toggle {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.todoist-board .task-description-toggle:hover,
+.todoist-board .task-description-toggle:focus-visible {
+  background: color-mix(in srgb, var(--background-modifier-hover) 70%, transparent);
+  color: var(--text-normal);
+  outline: none;
+}
+
 
 
 
@@ -1095,22 +1194,27 @@ input.todoist-checkbox::after {
   max-width: 220px;
 }
 
-/* Space reserved for chin/mini‑toolbar */
-:root {
-  --chin-height: 16px;
-}
-
-/* desktop/tablet default */
-@media (max-width: 600px) {
-  :root {
-    --chin-height: 22px;
-  }
-}
-
-/* mobile */
-
 .todoist-board .selected-task.has-fixed-chin .task-content-wrapper {
-  padding-bottom: var(--chin-height);
+  padding-bottom: 0;
+}
+
+.todoist-board .selected-task.has-fixed-chin .task-description.desc-empty {
+  display: none;
+  margin: 0;
+  max-height: 0;
+  opacity: 0;
+  padding: 0;
+}
+
+.todoist-board .selected-task.has-fixed-chin .task-description.has-description {
+  margin: 4px 0 0;
+  max-height: 5.6em;
+  padding: 0 28px 0 0;
+}
+
+.todoist-board .selected-task.has-fixed-chin .task-description.has-description.desc-expanded {
+  max-height: none;
+  overflow: visible;
 }
 
 .selected-task .mini-toolbar {
@@ -2045,6 +2149,24 @@ body.theme-dark .non-task-note {
   margin: 0 auto;
 }
 
+.todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin {
+  align-items: stretch;
+  bottom: auto;
+  display: flex;
+  flex: 0 0 auto;
+  left: auto;
+  margin: 0;
+  min-height: 0;
+  padding: 0;
+  position: static;
+  width: 100%;
+}
+
+.todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-inner {
+  margin: 0;
+  padding: 6px 4px;
+}
+
 
 .selected-task .mini-toolbar-wrapper .circle-btn.delete-btn {
   display: flex;
@@ -2124,7 +2246,7 @@ body.theme-dark .non-task-note {
   position: relative;
   max-width: 100%;
   width: 100%;
-  padding: 0.5rem 1rem 0.5rem;
+  padding: 0.375rem 0.25rem;
   align-items: flex-end;
   justify-content: flex-start;
   flex-direction: column;
@@ -2143,48 +2265,72 @@ body.theme-dark .non-task-note {
 .selected-task .chin-inner {
   box-sizing: border-box;
   display: flex;
-  gap: 0.25rem;
-  border-top: 1px solid rgba(0, 0, 0, 0.05);
+  gap: 0.375rem;
+  border-top: 1px solid rgba(180, 206, 245, 0.38);
   margin-top: 1rem;
   max-width: 100%;
   width: 100%;
   justify-content: flex-start;
-  flex-wrap: wrap;
-  background-color: rgba(243, 244, 246, 0.2);
-  /* light gray background */
-  border-radius: 6px;
-  padding: 0.5rem 0.75rem;
+  flex-wrap: nowrap;
+  background: color-mix(in srgb, var(--selected-bg) 88%, white 12%);
+  border-radius: 0 0 var(--selected-card-radius) var(--selected-card-radius);
+  padding: 0.375rem 0.25rem;
+}
+
+.selected-task .chin-actions {
+  align-items: center;
+  display: flex;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.selected-task .chin-actions-primary {
+  flex: 0 1 auto;
+}
+
+.selected-task .chin-actions-secondary {
+  flex: 0 0 auto;
+  margin-left: auto;
 }
 
 body.theme-dark .selected-task .chin-inner {
-  background-color: var(--background-primary, #1e1e1e);
-  border-radius: 12px;
+  background: color-mix(in srgb, var(--selected-bg) 88%, black 12%);
+  border-top-color: rgba(255, 255, 255, 0.08);
+  border-radius: 0 0 var(--selected-card-radius) var(--selected-card-radius);
 }
 
 .chin-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 6px;
-  background: white;
+  gap: 3px;
+  padding: 3px 7px;
+  border: 1px solid rgba(180, 206, 245, 0.58);
+  border-radius: var(--chin-button-radius);
+  background: color-mix(in srgb, var(--selected-bg) 72%, white 28%);
   color: #374151;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 500;
   cursor: pointer;
   box-shadow: none;
   transition: all var(--transition-fast);
 }
 
+.selected-task .task-hide-btn,
+.selected-task .delete-btn {
+  flex: 0 0 auto;
+  justify-content: center;
+  min-width: 34px;
+  padding-inline: 0;
+}
+
 
 .chin-btn:hover {
-  background: #f3f4f6;
-  border-color: #d1d5db;
+  background: color-mix(in srgb, var(--selected-bg) 55%, white 45%);
+  border-color: rgba(99, 102, 241, 0.26);
 }
 
 .chin-btn:active {
-  background: #e5e7eb;
+  background: color-mix(in srgb, var(--selected-bg) 48%, white 52%);
   transform: scale(0.97);
 }
 
@@ -2194,21 +2340,21 @@ body.theme-dark .selected-task .chin-inner {
 }
 
 body.theme-dark .chin-btn {
-  background: #1f2937;
-  border-color: #374151;
+  background: color-mix(in srgb, var(--selected-bg) 78%, white 6%);
+  border-color: rgba(255, 255, 255, 0.1);
   color: #f9fafb;
 }
 
 body.theme-dark .chin-btn:hover {
-  background: #374151;
-  border-color: #4b5563;
+  background: color-mix(in srgb, var(--selected-bg) 66%, white 10%);
+  border-color: rgba(255, 255, 255, 0.18);
 }
 
 /* Chin-Style Button Customizations for Selected Task */
 .selected-task .mini-toolbar-wrapper .delete-btn {
   color: red;
   right: 0;
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .selected-task .mini-toolbar-wrapper .delete-btn .lucide {
@@ -3434,7 +3580,7 @@ body.theme-dark .todoist-board .deadline-inline {
   overflow-y: auto;
 }
 
-/* Offscreen positioning for temporary utility elements */
+/* Offscreen positioning for clipboard textarea */
 .todoist-board .tb-fixed-offscreen {
   position: fixed;
   left: -10000px;
@@ -4090,6 +4236,13 @@ body.tb-scroll-lock {
 
 .settings-chin-preview-section {
   margin-top: 14px;
+}
+
+.settings-chin-preview-section.is-settings-focus-target {
+  border-radius: 8px;
+  outline: 2px solid rgba(99, 102, 241, 0.35);
+  outline-offset: 8px;
+  transition: outline-color var(--transition-medium);
 }
 
 .settings-chin-preview {
@@ -5701,12 +5854,13 @@ body.tb-scroll-lock {
   background: transparent;
   border: 0;
   box-shadow: none;
+  cursor: pointer;
   height: 100%;
   left: 0;
   margin: 0;
   opacity: 0;
   padding: 0;
-  pointer-events: auto;
+  pointer-events: none;
   position: absolute;
   right: 28px;
   top: 0;
@@ -5720,6 +5874,7 @@ body.tb-scroll-lock {
   border-radius: 7px;
   box-shadow: none;
   color: var(--text-muted);
+  cursor: pointer;
   display: inline-flex;
   font-size: 0.95rem;
   font-weight: 500;
@@ -5737,6 +5892,14 @@ body.tb-scroll-lock {
   outline: none;
 }
 
+.todoist-task-sheet-modal .taskmodal-more-settings-button {
+  font-size: 1rem;
+  justify-content: center;
+  letter-spacing: 1px;
+  min-width: 34px;
+  padding: 0 8px;
+}
+
 .todoist-task-sheet-modal .taskmodal-date-chip.has-value {
   color: #058527;
 }
@@ -5752,11 +5915,12 @@ body.tb-scroll-lock {
   border-radius: 7px;
   box-shadow: none;
   color: var(--text-muted);
+  cursor: pointer;
   display: inline-grid;
-  gap: 8px;
-  grid-template-columns: 18px minmax(0, auto);
+  gap: 6px;
+  grid-template-columns: 18px auto;
   height: 34px;
-  padding: 0 11px;
+  padding: 0 10px;
   position: relative;
 }
 
@@ -5795,9 +5959,10 @@ body.tb-scroll-lock {
   height: 32px;
   line-height: 32px;
   margin: 0;
-  min-width: 68px;
+  min-width: 0;
   padding: 0;
   text-align: left;
+  width: auto;
 }
 
 .todoist-task-sheet-modal .taskmodal-priority-menu {
@@ -5825,6 +5990,7 @@ body.tb-scroll-lock {
   border: 0;
   border-radius: 6px;
   color: var(--text-normal);
+  cursor: pointer;
   display: flex;
   font-size: 0.9rem;
   height: 34px;
@@ -5844,6 +6010,7 @@ body.tb-scroll-lock {
 
 .todoist-task-sheet-modal .taskmodal-chip-clear {
   color: var(--text-muted);
+  cursor: pointer;
   display: none;
   height: 16px;
   position: relative;
@@ -6048,6 +6215,7 @@ body.tb-scroll-lock {
 .todoist-task-sheet-modal .taskmodal-button-save,
 .todoist-task-sheet-modal .taskmodal-button-cancel {
   border-radius: 8px;
+  cursor: pointer;
   flex: 0 0 auto;
   font-size: 0.95rem;
   font-weight: 650;
@@ -6148,17 +6316,17 @@ body.tb-scroll-lock {
   }
 
   .todoist-task-sheet-modal .taskmodal-priority-field {
-    gap: 6px;
-    grid-template-columns: 16px minmax(0, auto);
+    gap: 5px;
+    grid-template-columns: 16px auto;
     height: 30px;
-    padding: 0 9px;
+    padding: 0 8px;
   }
 
   .todoist-task-sheet-modal .taskmodal-priority-button {
     font-size: 0.82rem;
     height: 28px;
     line-height: 28px;
-    min-width: 58px;
+    min-width: 0;
   }
 
   .todoist-task-sheet-modal .taskmodal-label-popover {
@@ -6344,6 +6512,10 @@ body.tb-scroll-lock {
     padding: 0;
   }
 
+  .todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner .task-content-wrapper {
+    padding-bottom: 0;
+  }
+
   .todoist-board .selected-task.has-fixed-chin > .task-scroll-wrapper > .task-inner {
     padding-bottom: 14px;
   }
@@ -6406,51 +6578,68 @@ body.tb-scroll-lock {
 
   .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-inner {
     align-items: center;
-    background: rgba(248, 250, 252, 0.78);
-    border-radius: 0;
-    border-top: 1px solid rgba(15, 23, 42, 0.08);
-    display: grid;
+    background: color-mix(in srgb, var(--selected-bg) 88%, white 12%);
+    border-radius: 0 0 var(--selected-card-radius) var(--selected-card-radius);
+    border-top: 1px solid rgba(180, 206, 245, 0.38);
+    display: flex;
+    flex-wrap: nowrap;
     gap: 4px;
-    grid-template-columns:
-      minmax(64px, 1fr)
-      minmax(62px, 1fr)
-      minmax(58px, 1fr)
-      minmax(42px, 0.68fr)
-      minmax(42px, 0.68fr);
-    justify-content: stretch;
+    justify-content: flex-start;
     margin: 0;
-    padding: 7px;
+    padding: 6px 4px;
     width: 100%;
+  }
+
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-actions {
+    display: flex;
+    gap: 4px;
+  }
+
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-actions-primary {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-actions-secondary {
+    flex: 0 0 auto;
+    margin-left: auto;
   }
 
   body.theme-dark .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-inner {
-    background: rgba(15, 23, 42, 0.34);
-    border-top-color: rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, var(--selected-bg) 88%, black 12%);
+    border-top-color: rgba(255, 255, 255, 0.08);
   }
 
   .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-btn {
-    flex: 1 1 0;
-    font-size: 0.76rem;
-    gap: 4px;
-    height: 36px;
+    flex: 0 0 auto;
+    font-size: 0.68rem;
+    gap: 3px;
+    height: 30px;
     justify-content: center;
-    min-height: 36px;
+    min-height: 30px;
     min-width: 0;
     overflow: hidden;
-    padding: 0 5px;
+    padding: 0 6px;
     white-space: nowrap;
-    width: 100%;
+    width: auto;
+  }
+
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .task-hide-btn,
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .delete-btn {
+    flex: 0 0 34px;
+    padding: 0;
+    width: 34px;
   }
 
   .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-btn svg {
     flex: 0 0 auto;
-    height: 20px;
+    height: 16px;
     margin: 0;
-    width: 20px;
+    width: 16px;
   }
 
   .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .chin-btn.delete-btn {
-    flex: 1 1 0;
+    flex: 0 0 34px;
     margin-left: 0;
     min-width: 0;
   }
@@ -6465,5 +6654,47 @@ body.tb-scroll-lock {
     display: flex;
     max-height: none;
     opacity: 1;
+  }
+}
+
+@media only screen and (max-width: 700px), (pointer: coarse) {
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description {
+    display: block;
+    max-height: 5.6em;
+    overflow: hidden;
+    padding: 0 28px 0 0;
+  }
+
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description.desc-expanded {
+    max-height: none;
+    overflow: visible;
+  }
+
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description .task-description-toggle {
+    opacity: 1;
+    pointer-events: auto;
+    touch-action: manipulation;
+    z-index: 2;
+  }
+}
+
+@media only screen and (max-width: 700px), (pointer: coarse) {
+  .todoist-board .selected-task .task-description.has-description.desc-collapsed {
+    display: block !important;
+    max-height: 5.6em !important;
+    overflow: hidden !important;
+    padding-right: 28px !important;
+  }
+
+  .todoist-board .selected-task .task-description.has-description.desc-expanded {
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .todoist-board .selected-task .task-description.has-description .task-description-toggle {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    touch-action: manipulation;
+    z-index: 2;
   }
 }


### PR DESCRIPTION
## Summary
- Polish the selected-task chin bar and description expansion behavior on mobile.
- Rename and reorganize settings tabs into Preferences and Advanced.
- Add Add Task modal field visibility preferences and a direct `...` shortcut from the modal to those settings.
- Improve Add Task modal mobile keyboard behavior, date labeling, compact priority controls, and date/label hitboxes.
- Bump release metadata to 2.0.7.

## Validation
- npm run typecheck
- npm run lint:obsidian
- npm test
- npm run build

Build completed with the existing Luxon circular dependency warnings.
