### PR TITLE
[codex] Polish mobile task controls

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2635,15 +2635,6 @@ export default class TodoistBoardPlugin extends Plugin {
       row.classList.add("parent-task");
     }
 
-    // Add repeating task icon if task is recurring ---
-    const isRepeating = !!task.due?.is_recurring;
-    if (isRepeating) {
-      const repeatIcon = activeDocument.createElement("span");
-      repeatIcon.classList.add("repeat-icon");
-      setIcon(repeatIcon, "repeat");
-      row.appendChild(repeatIcon);
-    }
-
     // Context Menu ---
     row.addEventListener("contextmenu", (event) => {
       event.preventDefault();
@@ -2813,12 +2804,14 @@ export default class TodoistBoardPlugin extends Plugin {
     let tapStartY = 0;
 
     row.addEventListener("pointerdown", (e: PointerEvent) => {
+      if ((e.target as HTMLElement).closest(".fixed-chin")) return;
       if (row.classList.contains("subtask-row")) return;
       tapStartX = e.clientX;
       tapStartY = e.clientY;
     });
 
     row.addEventListener("pointerup", (e: PointerEvent) => {
+      if ((e.target as HTMLElement).closest(".fixed-chin")) return;
       const isCheckbox = (e.target as HTMLElement).closest('input[type="checkbox"]');
       if (isCheckbox) return;
 
@@ -3013,11 +3006,19 @@ export default class TodoistBoardPlugin extends Plugin {
       label: string,
       onClick: (event: MouseEvent, button: HTMLButtonElement) => void,
       container: HTMLElement = primaryActions,
+      accessibleLabel: string = label,
     ) => {
       const button = activeDocument.createElement("button");
       button.className = `chin-btn ${className}`;
       setIcon(button, iconName);
       if (label) button.append(label);
+      if (accessibleLabel) {
+        button.title = accessibleLabel;
+        a11yButton(button, accessibleLabel);
+      }
+      ["pointerdown", "pointerup", "mousedown", "mouseup", "touchstart", "touchend"].forEach((eventName) => {
+        button.addEventListener(eventName, (event) => event.stopPropagation());
+      });
       button.onclick = (event) => onClick(event, button);
       container.appendChild(button);
       return button;
@@ -3040,13 +3041,13 @@ export default class TodoistBoardPlugin extends Plugin {
     }
 
     if (actions.editTask) {
-      appendChinButton("edit-btn", "pencil", "Edit", () => {
+      appendChinButton("edit-btn", "pencil", "", () => {
         void this.openEditTaskModalAsync(task, row, getFilters());
-      });
+      }, primaryActions, "Edit task");
     }
 
     if (actions.setPriority) {
-      appendChinButton("priority-btn", "flag", "Priority", (event) => {
+      appendChinButton("priority-btn", "flag", "", (event) => {
         event.preventDefault();
         event.stopPropagation();
         const pMenu = new Menu();
@@ -3055,7 +3056,7 @@ export default class TodoistBoardPlugin extends Plugin {
         pMenu.addItem((sub) => sub.setTitle("P3").setIcon("flag").onClick(async () => this.updateTaskPriority(task.id, 2, apiKey)));
         pMenu.addItem((sub) => sub.setTitle("P4 (low)").setIcon("flag").onClick(async () => this.updateTaskPriority(task.id, 1, apiKey)));
         pMenu.showAtPosition({ x: event.pageX, y: event.pageY });
-      });
+      }, primaryActions, "Set priority");
     }
 
     if (actions.setDeadline) {
@@ -3110,7 +3111,9 @@ export default class TodoistBoardPlugin extends Plugin {
     wrapper.appendChild(chinContainer);
     row.appendChild(wrapper);
 
-    wrapper.addEventListener("click", (e) => e.stopPropagation());
+    ["pointerdown", "pointerup", "mousedown", "mouseup", "touchstart", "touchend", "click"].forEach((eventName) => {
+      wrapper.addEventListener(eventName, (event) => event.stopPropagation());
+    });
   }
 
   // ======================= Edit Task Modal =======================

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "todoist-board",
   "name": "Todoist Board",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "minAppVersion": "1.8.7",
   "description": "Display Todoist tasks as draggable cards with full sync support.",
   "author": "JD",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todoist-board",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todoist-board",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "dependencies": {
         "luxon": "^3.7.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-board",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Obsidian plugin for visualizing Todoist tasks",
   "repository": "https://github.com/propranolol11/todoist-board",
   "main": "main.js",

--- a/src/modals/task-sheet-modal.ts
+++ b/src/modals/task-sheet-modal.ts
@@ -63,6 +63,7 @@ export class TaskSheetModal extends Modal {
     this.containerEl.style.removeProperty("--todoist-task-sheet-viewport-height");
     clearEl(this.contentEl);
     this.titleInput = null;
+    this.lastTextInput = null;
   }
 
   setLoading(title = this.options.title) {
@@ -86,39 +87,239 @@ export class TaskSheetModal extends Modal {
   }
 
   private rememberTextInput(input: HTMLInputElement | HTMLTextAreaElement) {
-    this.lastTextInput = input;
+    if (!this.lastTextInput) this.lastTextInput = input;
     input.addEventListener("focus", () => {
       this.lastTextInput = input;
     });
   }
 
-  private keepKeyboardOnPointerDown(element: HTMLElement) {
-    element.addEventListener("pointerdown", (event) => {
-      event.preventDefault();
-      this.lastTextInput?.focus();
-    });
+  private getActiveTextInput(): HTMLInputElement | HTMLTextAreaElement | null {
+    const focused = this.containerEl.ownerDocument.activeElement;
+    if (!(focused instanceof HTMLElement) || !this.contentEl.contains(focused)) return null;
+    if (focused.instanceOf(HTMLTextAreaElement)) return focused;
+    if (!focused.instanceOf(HTMLInputElement)) return null;
+    if ([
+      "button",
+      "checkbox",
+      "color",
+      "date",
+      "file",
+      "hidden",
+      "image",
+      "radio",
+      "range",
+      "reset",
+      "submit",
+      "time",
+    ].includes(focused.type)) {
+      return null;
+    }
+    return focused;
+  }
+
+  private isKeyboardTarget(input: HTMLInputElement | HTMLTextAreaElement | null): input is HTMLInputElement | HTMLTextAreaElement {
+    if (!input || !this.contentEl.contains(input) || input.disabled) return false;
+    const labelPopover = input.closest(".taskmodal-label-popover");
+    if (labelPopover && !labelPopover.closest(".taskmodal-label-anchor.is-open")) return false;
+    const datePopover = input.closest(".taskmodal-date-popover");
+    if (datePopover && !datePopover.classList.contains("is-open")) return false;
+    return true;
+  }
+
+  private getKeyboardTarget(): HTMLInputElement | HTMLTextAreaElement | null {
+    const activeInput = this.getActiveTextInput();
+    if (this.isKeyboardTarget(activeInput)) return activeInput;
+    if (this.isKeyboardTarget(this.lastTextInput)) return this.lastTextInput;
+    if (this.isKeyboardTarget(this.titleInput)) return this.titleInput;
+    return null;
+  }
+
+  private focusTextInput(input: HTMLInputElement | HTMLTextAreaElement) {
+    try {
+      input.focus({ preventScroll: true });
+    } catch {
+      input.focus();
+    }
   }
 
   private restoreTextFocus(delay = 0) {
-    const input = this.lastTextInput;
+    const input = this.getKeyboardTarget();
     if (!input) return;
-    window.setTimeout(() => input.focus(), delay);
+    if (delay <= 0) {
+      this.focusTextInput(input);
+      return;
+    }
+    window.setTimeout(() => this.focusTextInput(input), delay);
   }
 
-  private openDatePicker(input: HTMLInputElement) {
-    const dateInput = input as HTMLInputElement & { showPicker?: () => void };
-    if (typeof dateInput.showPicker === "function") {
-      try {
-        dateInput.showPicker();
-        this.restoreTextFocus();
-        return;
-      } catch {
-        // Fall back to a normal click for hosts that expose but reject showPicker.
-      }
+  private keepKeyboardOnPointerDown(element: HTMLElement) {
+    if (element.instanceOf(HTMLButtonElement)) {
+      element.tabIndex = -1;
     }
-    input.click();
+
+    element.addEventListener("focus", () => this.restoreTextFocus());
+    element.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      this.restoreTextFocus();
+    });
+    element.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      this.restoreTextFocus();
+    });
+    element.addEventListener("touchstart", (event) => {
+      event.stopPropagation();
+      this.restoreTextFocus();
+    }, { passive: true });
+  }
+
+  private parseDateValue(value: string): Date | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]) - 1;
+    const day = Number(match[3]);
+    const date = new Date(year, month, day);
+    if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) return null;
+    return date;
+  }
+
+  private toDateValue(date: Date): string {
+    const month = `${date.getMonth() + 1}`.padStart(2, "0");
+    const day = `${date.getDate()}`.padStart(2, "0");
+    return `${date.getFullYear()}-${month}-${day}`;
+  }
+
+  private dispatchInputChange(input: HTMLInputElement) {
+    const EventCtor = input.ownerDocument.defaultView?.Event ?? Event;
+    input.dispatchEvent(new EventCtor("change", { bubbles: true }));
+  }
+
+  private sameDay(a: Date, b: Date): boolean {
+    return a.getFullYear() === b.getFullYear()
+      && a.getMonth() === b.getMonth()
+      && a.getDate() === b.getDate();
+  }
+
+  private initialCalendarMonth(value: string): Date {
+    const selected = this.parseDateValue(value) ?? new Date();
+    return new Date(selected.getFullYear(), selected.getMonth(), 1);
+  }
+
+  private closeDatePopovers(except?: HTMLElement) {
+    this.contentEl.querySelectorAll<HTMLElement>(".taskmodal-date-popover.is-open").forEach((popover) => {
+      if (popover === except) return;
+      popover.classList.remove("is-open");
+      popover.closest(".taskmodal-date-anchor")?.classList.remove("is-open");
+    });
+  }
+
+  private openDatePopover(anchor: HTMLElement, popover: HTMLElement, input: HTMLInputElement, monthState: { value: Date }) {
+    const willOpen = !popover.classList.contains("is-open");
+    this.closeDatePopovers(popover);
+    anchor.classList.toggle("is-open", willOpen);
+    popover.classList.toggle("is-open", willOpen);
+    if (willOpen) {
+      monthState.value = this.initialCalendarMonth(input.value);
+      this.renderDatePopover(anchor, popover, input, monthState);
+    }
     this.restoreTextFocus();
-    this.restoreTextFocus(250);
+  }
+
+  private renderDatePopover(anchor: HTMLElement, popover: HTMLElement, input: HTMLInputElement, monthState: { value: Date }) {
+    clearEl(popover);
+    if (!popover.dataset.keyboardGuardInstalled) {
+      ["pointerdown", "mousedown", "touchstart", "click"].forEach((eventName) => {
+        popover.addEventListener(eventName, (event) => event.stopPropagation());
+      });
+      popover.dataset.keyboardGuardInstalled = "true";
+    }
+    const selectedDate = this.parseDateValue(input.value);
+    const today = new Date();
+    const monthStart = new Date(monthState.value.getFullYear(), monthState.value.getMonth(), 1);
+    const firstGridDay = new Date(monthStart);
+    firstGridDay.setDate(1 - monthStart.getDay());
+
+    const header = popover.createDiv({ cls: "taskmodal-date-popover-header" });
+    const prevButton = header.createEl("button", { cls: "taskmodal-date-nav", type: "button" });
+    setIcon(prevButton, "chevron-left");
+    header.createDiv({
+      cls: "taskmodal-date-month",
+      text: monthStart.toLocaleDateString(undefined, { month: "long", year: "numeric" }),
+    });
+    const nextButton = header.createEl("button", { cls: "taskmodal-date-nav", type: "button" });
+    setIcon(nextButton, "chevron-right");
+
+    const moveMonth = (offset: number) => {
+      monthState.value = new Date(monthState.value.getFullYear(), monthState.value.getMonth() + offset, 1);
+      this.renderDatePopover(anchor, popover, input, monthState);
+      this.restoreTextFocus();
+      this.restoreTextFocus(80);
+    };
+
+    [prevButton, nextButton].forEach((button) => this.keepKeyboardOnPointerDown(button));
+    prevButton.onclick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      moveMonth(-1);
+    };
+    nextButton.onclick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      moveMonth(1);
+    };
+
+    const weekdays = popover.createDiv({ cls: "taskmodal-date-weekdays" });
+    ["S", "M", "T", "W", "T", "F", "S"].forEach((day) => {
+      weekdays.createSpan({ text: day });
+    });
+
+    const grid = popover.createDiv({ cls: "taskmodal-date-grid" });
+    for (let index = 0; index < 42; index += 1) {
+      const date = new Date(firstGridDay);
+      date.setDate(firstGridDay.getDate() + index);
+      const button = grid.createEl("button", {
+        cls: "taskmodal-date-day",
+        text: String(date.getDate()),
+        type: "button",
+      });
+      button.classList.toggle("is-muted", date.getMonth() !== monthStart.getMonth());
+      button.classList.toggle("is-today", this.sameDay(date, today));
+      button.classList.toggle("is-selected", !!selectedDate && this.sameDay(date, selectedDate));
+      this.keepKeyboardOnPointerDown(button);
+      button.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        input.value = this.toDateValue(date);
+        this.dispatchInputChange(input);
+        popover.classList.remove("is-open");
+        anchor.classList.remove("is-open");
+        this.restoreTextFocus();
+      };
+    }
+
+    const footer = popover.createDiv({ cls: "taskmodal-date-popover-footer" });
+    const cancelButton = footer.createEl("button", { cls: "taskmodal-date-cancel", text: "Cancel", type: "button" });
+    const todayButton = footer.createEl("button", { cls: "taskmodal-date-today", text: "Today", type: "button" });
+    this.keepKeyboardOnPointerDown(cancelButton);
+    this.keepKeyboardOnPointerDown(todayButton);
+    cancelButton.onclick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      popover.classList.remove("is-open");
+      anchor.classList.remove("is-open");
+      this.restoreTextFocus();
+    };
+    todayButton.onclick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      input.value = this.toDateValue(new Date());
+      this.dispatchInputChange(input);
+      popover.classList.remove("is-open");
+      anchor.classList.remove("is-open");
+      this.restoreTextFocus();
+    };
   }
 
   private renderForm() {
@@ -299,6 +500,10 @@ export class TaskSheetModal extends Modal {
       type: "date",
       value: fields.due ?? "",
     });
+    const duePopover = visibleFields.dueDate
+      ? dueAnchor.createDiv({ cls: "taskmodal-date-popover" })
+      : ownerDocument.createElement("div");
+    const dueMonthState = { value: this.initialCalendarMonth(fields.due ?? "") };
 
     if (visibleFields.dueDate) {
       const dueChip = dueAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-date-chip" });
@@ -319,14 +524,14 @@ export class TaskSheetModal extends Modal {
       dueChip.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
-        this.openDatePicker(dueInput);
+        this.openDatePopover(dueAnchor, duePopover, dueInput, dueMonthState);
       };
       dueClear.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
         dueInput.value = "";
         syncDueChip();
-        this.lastTextInput?.focus();
+        this.restoreTextFocus();
       };
       this.keepKeyboardOnPointerDown(dueClear);
       dueInput.addEventListener("change", syncDueChip);
@@ -341,6 +546,10 @@ export class TaskSheetModal extends Modal {
       type: "date",
       value: fields.deadline ?? "",
     });
+    const deadlinePopover = visibleFields.deadline
+      ? deadlineAnchor.createDiv({ cls: "taskmodal-date-popover taskmodal-date-popover-right" })
+      : ownerDocument.createElement("div");
+    const deadlineMonthState = { value: this.initialCalendarMonth(fields.deadline ?? "") };
 
     if (visibleFields.deadline) {
       const deadlineChip = deadlineAnchor.createEl("button", { cls: "taskmodal-chip taskmodal-deadline-chip" });
@@ -361,14 +570,14 @@ export class TaskSheetModal extends Modal {
       deadlineChip.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
-        this.openDatePicker(deadlineInput);
+        this.openDatePopover(deadlineAnchor, deadlinePopover, deadlineInput, deadlineMonthState);
       };
       deadlineClear.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
         deadlineInput.value = "";
         syncDeadlineChip();
-        this.lastTextInput?.focus();
+        this.restoreTextFocus();
       };
       this.keepKeyboardOnPointerDown(deadlineClear);
       deadlineInput.addEventListener("change", syncDeadlineChip);
@@ -408,7 +617,7 @@ export class TaskSheetModal extends Modal {
         priorityButton.textContent = priorityLabel(Number(prioritySelect.value));
         priorityButton.setAttribute("aria-label", priorityLabel(Number(prioritySelect.value)));
         priorityMenu.classList.remove("is-open");
-        this.lastTextInput?.focus();
+        this.restoreTextFocus();
       };
     });
     priorityField.setAttribute("data-priority", String(fields.priority ?? 1));
@@ -421,7 +630,7 @@ export class TaskSheetModal extends Modal {
         event.preventDefault();
         event.stopPropagation();
         priorityMenu.classList.toggle("is-open");
-        this.lastTextInput?.focus();
+        this.restoreTextFocus();
       };
     }
 
@@ -496,11 +705,25 @@ export class TaskSheetModal extends Modal {
     syncLabelChip();
 
     if (visibleFields.labels) {
+      const labelFooter = labelPopover.createDiv({ cls: "taskmodal-label-popover-footer" });
+      const labelCancelButton = labelFooter.createEl("button", {
+        cls: "taskmodal-label-cancel",
+        text: "Cancel",
+        type: "button",
+      });
+      this.keepKeyboardOnPointerDown(labelCancelButton);
+      labelCancelButton.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        labelAnchor.classList.remove("is-open");
+        this.restoreTextFocus();
+      };
+
       labelButton.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
         labelAnchor.classList.toggle("is-open");
-        this.lastTextInput?.focus();
+        this.restoreTextFocus();
       };
       labelPopover.addEventListener("click", (event) => event.stopPropagation());
       labelSearch.addEventListener("input", () => {
@@ -529,6 +752,9 @@ export class TaskSheetModal extends Modal {
     }
 
     wrapper.addEventListener("click", (event) => {
+      if (!(event.target as HTMLElement).closest(".taskmodal-date-anchor")) {
+        this.closeDatePopovers();
+      }
       if (!(event.target as HTMLElement).closest(".taskmodal-label-anchor")) {
         labelAnchor.classList.remove("is-open");
       }

--- a/src/task-rendering.ts
+++ b/src/task-rendering.ts
@@ -109,6 +109,7 @@ export function createTaskContent(options: TaskContentRenderOptions): HTMLElemen
       toggleExpandedDescription();
     };
     descEl.appendChild(toggleDescription);
+    scheduleDescriptionOverflowSync(descEl);
   } else {
     descEl.classList.add("desc-empty");
   }
@@ -116,6 +117,7 @@ export function createTaskContent(options: TaskContentRenderOptions): HTMLElemen
   const contentWrapper = activeDocument.createElement("div");
   contentWrapper.className = "task-content-wrapper";
   contentWrapper.appendChild(titleSpan);
+  contentWrapper.appendChild(descEl);
 
   const whenRow = activeDocument.createElement("div");
   whenRow.className = "task-when";
@@ -138,7 +140,7 @@ export function createTaskContent(options: TaskContentRenderOptions): HTMLElemen
   const projectInline = createProjectPill(task.projectId, projectMap, projects);
   if (projectInline) metaRow.appendChild(projectInline);
 
-  const labelsInline = createLabelPill(task.labels, labelMap, labelColorMap, labels);
+  const labelsInline = createLabelPill(task.labels, labelMap, labelColorMap, labels, isTaskRecurring(task));
   if (labelsInline) {
     if (projectInline) {
       metaRow.appendChild(createMidSeparator());
@@ -147,11 +149,29 @@ export function createTaskContent(options: TaskContentRenderOptions): HTMLElemen
   }
   contentWrapper.appendChild(metaRow);
 
-  contentWrapper.appendChild(descEl);
   contentWrapper.appendChild(metaSpan);
   left.appendChild(contentWrapper);
 
   return left;
+}
+
+function scheduleDescriptionOverflowSync(descEl: HTMLElement) {
+  const sync = () => {
+    const wasExpanded = descEl.classList.contains("desc-expanded");
+    if (wasExpanded) descEl.classList.remove("desc-expanded");
+    descEl.classList.add("desc-collapsed");
+    const hasOverflow = descEl.scrollHeight > descEl.clientHeight + 1;
+    descEl.classList.toggle("has-overflow", hasOverflow);
+    if (wasExpanded) {
+      descEl.classList.toggle("desc-expanded", hasOverflow);
+      descEl.classList.toggle("desc-collapsed", !hasOverflow);
+    }
+  };
+
+  window.requestAnimationFrame(() => {
+    sync();
+    window.setTimeout(sync, 60);
+  });
 }
 
 interface TaskPillOptions {
@@ -195,7 +215,7 @@ function createTaskPills(options: TaskPillOptions): HTMLElement[] {
   const projectPill = createProjectPill(task.projectId, projectMap, projects);
   if (projectPill) pills.push(projectPill);
 
-  const labelPill = createLabelPill(task.labels, labelMap, labelColorMap, labels);
+  const labelPill = createLabelPill(task.labels, labelMap, labelColorMap, labels, isTaskRecurring(task));
   if (labelPill) pills.push(labelPill);
 
   return pills.filter((pill) => pill.style.display !== "none");
@@ -223,11 +243,7 @@ function createDueInline(task: TodoistTask, settings: TodoistBoardSettings): HTM
   span.className = "due-inline";
   span.textContent = hasTime ? `${dateLabel} @ ${dt.toFormat(useHour12() ? "h:mm a" : "HH:mm")}` : dateLabel;
 
-  const isRecurring = Boolean(
-    task?.due?.isRecurring === true ||
-    (typeof task?.due?.string === "string" && /\b(every|daily|weekly|monthly|yearly|weekday|weekend)\b/i.test(task.due.string))
-  );
-  if (isRecurring) {
+  if (isTaskRecurring(task)) {
     const recurring = activeDocument.createElement("span");
     recurring.className = "repeat-indicator";
     recurring.setAttribute("aria-label", "Repeats");
@@ -237,6 +253,14 @@ function createDueInline(task: TodoistTask, settings: TodoistBoardSettings): HTM
   }
 
   return span;
+}
+
+function isTaskRecurring(task: TodoistTask): boolean {
+  return Boolean(
+    task?.due?.isRecurring === true ||
+    task?.due?.is_recurring === true ||
+    (typeof task?.due?.string === "string" && /\b(every|daily|weekly|monthly|yearly|weekday|weekend)\b/i.test(task.due.string))
+  );
 }
 
 function createDeadlineInline(task: TodoistTask, settings: TodoistBoardSettings): HTMLElement | null {
@@ -365,6 +389,7 @@ function createLabelPill(
   labelMap: Record<string, string>,
   labelColorMap: Record<string, string>,
   labelCache: Label[],
+  hideLeadingRepeatEmoji = false,
 ): HTMLElement | null {
   if (!Array.isArray(labels) || labels.length === 0) return null;
 
@@ -386,7 +411,11 @@ function createLabelPill(
   labels.forEach((raw, index) => {
     const input = String(raw);
     const idKey = resolveIdKey(input);
-    const name = idKey ? (labelMap[idKey] ?? input) : input;
+    const rawName = idKey ? (labelMap[idKey] ?? input) : input;
+    const repeatStrippedName = rawName.replace(/^\s*(?:🔁|🔄|↻|⟳|⟲)\s*/u, "");
+    const name = hideLeadingRepeatEmoji && repeatStrippedName.trim()
+      ? repeatStrippedName
+      : rawName;
 
     let rawColor: string | number | undefined = idKey ? labelColorMap[idKey] : undefined;
     if (!rawColor && labelColorMap[input] !== undefined) {

--- a/styles.css
+++ b/styles.css
@@ -1003,6 +1003,18 @@ input.todoist-checkbox::after {
   position: relative;
 }
 
+.todoist-board .selected-task .task-description.has-description {
+  background: color-mix(in srgb, var(--selected-bg, var(--background-primary)) 62%, var(--background-secondary) 38%);
+  border-left: 3px solid color-mix(in srgb, var(--todoist-red) 58%, var(--background-secondary) 42%);
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--background-modifier-border) 44%, transparent);
+  color: color-mix(in srgb, var(--text-normal) 82%, var(--text-muted) 18%);
+  font-style: normal;
+  margin-top: 6px;
+  opacity: 1;
+  padding: 7px 32px 7px 10px;
+}
+
 .todoist-board .selected-task .task-description.desc-expanded {
   max-height: none;
   overflow: visible;
@@ -1135,8 +1147,8 @@ input.todoist-checkbox::after {
   width: 16px;
 }
 
-.todoist-board .selected-task .task-description.has-description:hover .task-description-toggle,
-.todoist-board .selected-task .task-description.has-description:focus-within .task-description-toggle {
+.todoist-board .selected-task .task-description.has-description.has-overflow:hover .task-description-toggle,
+.todoist-board .selected-task .task-description.has-description.has-overflow:focus-within .task-description-toggle {
   opacity: 1;
   pointer-events: auto;
 }
@@ -1209,7 +1221,7 @@ input.todoist-checkbox::after {
 .todoist-board .selected-task.has-fixed-chin .task-description.has-description {
   margin: 4px 0 0;
   max-height: 5.6em;
-  padding: 0 28px 0 0;
+  padding: 7px 32px 7px 10px;
 }
 
 .todoist-board .selected-task.has-fixed-chin .task-description.has-description.desc-expanded {
@@ -2316,6 +2328,8 @@ body.theme-dark .selected-task .chin-inner {
 }
 
 .selected-task .task-hide-btn,
+.selected-task .edit-btn,
+.selected-task .priority-btn,
 .selected-task .delete-btn {
   flex: 0 0 auto;
   justify-content: center;
@@ -3270,26 +3284,9 @@ body.theme-dark .todoist-edit-task-modal .taskmodal-label-checkbox {
   z-index: 9999;
 }
 
-.todoist-board .task .repeat-icon {
-  position: absolute;
-  padding-left: 0.5rem;
-  bottom: 0.75rem;
-  opacity: 0.3;
-  width: 16px;
-  height: 16px;
-}
-
-.todoist-board .task.selected-task .repeat-icon {
-  opacity: 0;
-}
-
 /* === Hide Icons in Compact Mode === */
 /* === Hide Icons in Compact Mode === */
 /* === Hide Icons in Compact Mode for list-wrapper === */
-.todoist-board .list-wrapper.compact-mode .repeat-icon {
-  display: none;
-}
-
 /* Inline parent marker (emoji) */
 .parent-mark {
   margin-left: 6px;
@@ -5908,6 +5905,140 @@ body.tb-scroll-lock {
   color: #7c3aed;
 }
 
+.todoist-task-sheet-modal .taskmodal-date-anchor.is-open {
+  z-index: 10030;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-popover {
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  display: none;
+  left: 0;
+  padding: 10px;
+  position: absolute;
+  top: calc(100% + 8px);
+  width: min(320px, calc(100vw - 32px));
+  z-index: 10020;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-popover-right {
+  left: auto;
+  right: 0;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-popover.is-open {
+  display: block;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-popover-header {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 32px minmax(0, 1fr) 32px;
+  margin-bottom: 8px;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-nav,
+.todoist-task-sheet-modal .taskmodal-date-day,
+.todoist-task-sheet-modal .taskmodal-date-today {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  color: var(--text-normal);
+  cursor: pointer;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-nav {
+  align-items: center;
+  border-radius: 6px;
+  display: inline-flex;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  width: 32px;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-month {
+  color: var(--text-normal);
+  font-size: 0.95rem;
+  font-weight: 650;
+  text-align: center;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-weekdays,
+.todoist-task-sheet-modal .taskmodal-date-grid {
+  display: grid;
+  gap: 2px;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.todoist-task-sheet-modal .taskmodal-date-weekdays {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 650;
+  margin-bottom: 4px;
+  text-align: center;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-day {
+  border-radius: 6px;
+  font-size: 0.9rem;
+  height: 34px;
+  padding: 0;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-day.is-muted {
+  color: var(--text-faint);
+}
+
+.todoist-task-sheet-modal .taskmodal-date-day.is-today {
+  color: var(--todoist-red);
+  font-weight: 700;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-day.is-selected {
+  background: var(--todoist-red);
+  color: white;
+  font-weight: 700;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-nav:hover,
+.todoist-task-sheet-modal .taskmodal-date-day:hover,
+.todoist-task-sheet-modal .taskmodal-date-today:hover {
+  background: var(--background-modifier-hover);
+}
+
+.todoist-task-sheet-modal .taskmodal-date-day.is-selected:hover {
+  background: var(--todoist-red);
+}
+
+.todoist-task-sheet-modal .taskmodal-date-popover-footer {
+  border-top: 1px solid var(--background-modifier-border);
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+  padding-top: 8px;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-cancel,
+.todoist-task-sheet-modal .taskmodal-date-today {
+  border-radius: 6px;
+  font-size: 0.86rem;
+  font-weight: 650;
+  height: 30px;
+  padding: 0 10px;
+}
+
+.todoist-task-sheet-modal .taskmodal-date-cancel {
+  color: var(--text-muted);
+}
+
+.todoist-task-sheet-modal .taskmodal-date-today {
+  color: var(--todoist-red);
+}
+
 .todoist-task-sheet-modal .taskmodal-priority-field {
   align-items: center;
   background: transparent;
@@ -6068,6 +6199,30 @@ body.tb-scroll-lock {
   max-height: 340px;
   overflow-y: auto;
   padding: 0 0 8px;
+}
+
+.todoist-task-sheet-modal .taskmodal-label-popover-footer {
+  border-top: 1px solid var(--background-modifier-border);
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 12px;
+}
+
+.todoist-task-sheet-modal .taskmodal-label-cancel {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 650;
+  height: 30px;
+  padding: 0 10px;
+}
+
+.todoist-task-sheet-modal .taskmodal-label-cancel:hover {
+  background: var(--background-modifier-hover);
 }
 
 .todoist-task-sheet-modal .taskmodal-label-option {
@@ -6339,7 +6494,29 @@ body.tb-scroll-lock {
   }
 
   .todoist-task-sheet-modal .taskmodal-label-list {
-    max-height: calc(min(62vh, 440px) - 66px);
+    max-height: calc(min(62vh, 440px) - 115px);
+  }
+
+  .todoist-task-sheet-modal .taskmodal-date-popover,
+  .todoist-task-sheet-modal .taskmodal-date-popover-right {
+    left: 12px;
+    max-height: min(62vh, 440px);
+    overflow-y: auto;
+    position: fixed;
+    right: 12px;
+    top: max(72px, env(safe-area-inset-top));
+    width: auto;
+  }
+
+  .todoist-task-sheet-modal.is-keyboard-open .taskmodal-date-popover,
+  .todoist-task-sheet-modal.is-keyboard-open .taskmodal-date-popover-right {
+    bottom: calc(var(--todoist-task-sheet-keyboard-offset, 0px) + max(8px, env(safe-area-inset-bottom)));
+    max-height: min(44vh, calc(var(--todoist-task-sheet-viewport-height, 100dvh) - 16px));
+    top: auto;
+  }
+
+  .todoist-task-sheet-modal .taskmodal-date-day {
+    height: 32px;
   }
 
   .todoist-task-sheet-modal .taskmodal-footer-row {
@@ -6540,7 +6717,7 @@ body.tb-scroll-lock {
     display: block;
     margin: 6px 0 0;
     overflow: visible;
-    padding: 0;
+    padding: 7px 32px 7px 10px;
   }
 
   .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description:empty {
@@ -6625,6 +6802,8 @@ body.tb-scroll-lock {
   }
 
   .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .task-hide-btn,
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .edit-btn,
+  .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .priority-btn,
   .todoist-board .selected-task > #mini-toolbar-wrapper.fixed-chin .delete-btn {
     flex: 0 0 34px;
     padding: 0;
@@ -6662,7 +6841,7 @@ body.tb-scroll-lock {
     display: block;
     max-height: 5.6em;
     overflow: hidden;
-    padding: 0 28px 0 0;
+    padding: 7px 32px 7px 10px;
   }
 
   .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description.desc-expanded {
@@ -6670,7 +6849,7 @@ body.tb-scroll-lock {
     overflow: visible;
   }
 
-  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description .task-description-toggle {
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description.has-overflow .task-description-toggle {
     opacity: 1;
     pointer-events: auto;
     touch-action: manipulation;
@@ -6679,21 +6858,21 @@ body.tb-scroll-lock {
 }
 
 @media only screen and (max-width: 700px), (pointer: coarse) {
-  .todoist-board .selected-task .task-description.has-description.desc-collapsed {
-    display: block !important;
-    max-height: 5.6em !important;
-    overflow: hidden !important;
-    padding-right: 28px !important;
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description.desc-collapsed {
+    display: block;
+    max-height: 5.6em;
+    overflow: hidden;
+    padding: 7px 32px 7px 10px;
   }
 
-  .todoist-board .selected-task .task-description.has-description.desc-expanded {
-    max-height: none !important;
-    overflow: visible !important;
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description.desc-expanded {
+    max-height: none;
+    overflow: visible;
   }
 
-  .todoist-board .selected-task .task-description.has-description .task-description-toggle {
-    opacity: 1 !important;
-    pointer-events: auto !important;
+  .todoist-board .selected-task > .task-scroll-wrapper > .task-inner .task-description.has-description.has-overflow .task-description-toggle {
+    opacity: 1;
+    pointer-events: auto;
     touch-action: manipulation;
     z-index: 2;
   }


### PR DESCRIPTION
## Summary
- Reworked the add task modal mobile controls so date/deadline use a keyboard-preserving custom calendar with cancel actions, and label selection also has a cancel action.
- Tightened selected-task card presentation: compact chin actions, persistent selection while using chin actions, clearer description placement/background, overflow-only description chevrons, and cleaner recurring task indicators.
- Bumped the release version to 2.0.8 across package metadata and manifest.

## Why
These changes address mobile usability issues where native date controls dismissed the keyboard, chin bar actions could deselect cards, repeated-task indicators were visually noisy, and selected-card descriptions lacked clear placement and contrast.

## Validation
- npm run verify
  - typecheck
  - lint:obsidian
  - tests
  - build
  - npm audit

Note: build still reports the existing Luxon circular dependency notices from Rollup.