### PR TITLE
[codex] Add secure token storage for 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Todoist Board
 
+> [!IMPORTANT]
+> If you update to Todoist Board 2.1.0 and your tasks do not load, open the plugin settings and re-enter your Todoist API token. Todoist Board now uses Obsidian Secret Storage for API tokens when available, which keeps the token out of the plugin's `data.json` file.
+
 Todoist Board is an Obsidian plugin that displays Todoist tasks as interactive boards in the sidebar or directly inside notes.
 
 ## Disclosures

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Todoist Board is an Obsidian plugin that displays Todoist tasks as interactive b
 
 - Requires a Todoist account and a Todoist personal API token.
 - Connects to the Todoist REST and Sync APIs to fetch, create, update, schedule, move, and complete tasks.
-- Stores the Todoist API token and plugin preferences locally with Obsidian's plugin data storage.
+- Stores the Todoist API token with Obsidian Secret Storage when available, falling back to plugin data storage on older Obsidian versions.
+- Stores non-secret plugin preferences locally with Obsidian's plugin data storage.
 - Caches task snapshots, project metadata, label metadata, hidden-task state, sort mode, compact mode, and manual order locally for responsiveness and offline display.
 - Does not collect analytics, use telemetry, or send data to any service other than Todoist.
 - Includes an optional funding link in the plugin settings and manifest.
@@ -25,7 +26,7 @@ This plugin is not affiliated with, endorsed by, or sponsored by Todoist.
 
 ## Setup
 
-Todoist Board requires Obsidian 1.8.7 or newer.
+Todoist Board requires Obsidian 1.8.7 or newer. Obsidian 1.11.4 or newer is recommended for Secret Storage support.
 
 1. Install the plugin in Obsidian.
 2. Open Obsidian settings and go to Todoist Board.
@@ -34,6 +35,7 @@ Todoist Board requires Obsidian 1.8.7 or newer.
 5. Open the command palette and run `Open Todoist Board`.
 
 You can create a Todoist personal API token from Todoist account settings.
+Existing plugin-data tokens are migrated to Obsidian Secret Storage automatically when Secret Storage is available.
 
 ## Inline Boards
 

--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,7 @@ import {
 } from "./src/storage";
 import { StorageRepository } from "./src/storage-repository";
 import { TaskStore } from "./src/task-store";
+import { TodoistTokenStorage } from "./src/token-storage";
 import { TodoistService, isTodoistRequestError, type TodoistTaskFetchResult } from "./src/todoist-service";
 import { TaskActions } from "./src/task-actions";
 import { TaskSheetModal } from "./src/modals/task-sheet-modal";
@@ -185,6 +186,7 @@ export default class TodoistBoardPlugin extends Plugin {
   private storage!: TodoistBoardStorage;
   private storageRepository!: StorageRepository;
   private taskStoreController!: TaskStore;
+  private tokenStorage?: TodoistTokenStorage;
   private todoistService!: TodoistService;
   private taskActions!: TaskActions;
   private stopTaskPolling?: () => void;
@@ -350,14 +352,30 @@ export default class TodoistBoardPlugin extends Plugin {
     }
     return this.storage.loadMetadata();
   }
+
+  private getTokenStorage() {
+    if (!this.tokenStorage) this.tokenStorage = new TodoistTokenStorage(this.app);
+    return this.tokenStorage;
+  }
+
+  private async saveStoredSettings() {
+    await this.saveData(this.getTokenStorage().prepareSettingsForSave(this.settings));
+  }
+
   async loadSettings() {
     const saved: unknown = await this.loadData();
-    this.settings = normalizeSettings(
+    const settings = normalizeSettings(
       saved && typeof saved === "object" ? saved : undefined
     );
+    const tokenLoad = this.getTokenStorage().loadToken(settings.apiKey);
+    this.settings = { ...settings, apiKey: tokenLoad.token };
+
+    if (tokenLoad.shouldRewriteSettings) {
+      await this.saveStoredSettings();
+    }
   }
   async saveSettings() {
-    await this.saveData(this.settings);
+    await this.saveStoredSettings();
     // refresh inline boards
     activeDocument.querySelectorAll(".todoist-inline-board").forEach((el) => {
       el.dispatchEvent(new CustomEvent("todoist-inline-refresh", { bubbles: true }));
@@ -1146,7 +1164,7 @@ export default class TodoistBoardPlugin extends Plugin {
 
   // ======================= 🧹 Persistence & Cleanup =======================
   async savePluginData() {
-    await this.saveData(this.settings);
+    await this.saveStoredSettings();
     this.refreshAllInlineBoards();
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "todoist-board",
   "name": "Todoist Board",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "minAppVersion": "1.8.7",
   "description": "Display Todoist tasks as draggable cards with full sync support.",
   "author": "JD",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todoist-board",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todoist-board",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "dependencies": {
         "luxon": "^3.7.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-board",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Obsidian plugin for visualizing Todoist tasks",
   "repository": "https://github.com/propranolol11/todoist-board",
   "main": "main.js",

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -80,7 +80,6 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
     const authCard = container.createDiv({ cls: "todoist-settings-card todoist-settings-auth-card" });
     new Setting(authCard)
       .setName("API token")
-      .setDesc("Stored locally in this vault.")
       .addText((text) => {
         text
           .setPlaceholder("Paste API token")
@@ -100,7 +99,7 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
             const valid = await this.plugin.validateTodoistApiKey(text.inputEl.value);
             if (!valid) throw new Error("Invalid");
             pluginSettings.apiKey = text.inputEl.value;
-            indicator.textContent = "Saved";
+            indicator.textContent = "Saved securely";
             await this.plugin.savePluginData();
           } catch {
             indicator.textContent = "Invalid token";
@@ -125,13 +124,39 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
       "help-circle",
     );
 
+    const securityNote = authCard.createEl("details", { cls: "todoist-settings-security-note" });
+    securityNote.createEl("summary", { text: "How is my token stored?" });
+    const securityCopy = securityNote.createEl("p");
+    securityCopy.appendText("Todoist Board stores your API token in Obsidian Secret Storage when available, with plugin data fallback for older Obsidian versions. ");
+    securityCopy.createEl("a", {
+      href: "https://docs.obsidian.md/plugins/guides/secret-storage",
+      text: "Obsidian docs",
+    }).setAttribute("target", "_blank");
+    securityCopy.querySelector("a")?.setAttribute("rel", "noopener noreferrer");
+
     const nextSection = container.createDiv({ cls: "todoist-settings-card todoist-settings-next" });
     this.renderHeading(nextSection, "Next", "todoist-settings-card-title");
     const nextList = nextSection.createEl("ul", { cls: "todoist-settings-next-list" });
     nextList.createEl("li", { text: "Command palette: Open Todoist Board" });
     const codeItem = nextList.createEl("li");
-    codeItem.appendText("Embed: ");
-    codeItem.createEl("code", { text: "Filter: today" });
+    codeItem.appendText("Inline board:");
+    const snippet = "```todoist-board\nfilter: today\n```";
+    const snippetWrapper = codeItem.createDiv({ cls: "todoist-settings-copy-code" });
+    const snippetPre = snippetWrapper.createEl("pre", { cls: "todoist-settings-code-example" });
+    snippetPre.createEl("code", { text: snippet });
+    const copyButton = snippetWrapper.createEl("button", {
+      cls: "todoist-settings-copy-code-button",
+      text: "Copy",
+      type: "button",
+    });
+    copyButton.onclick = async () => {
+      try {
+        await navigator.clipboard.writeText(snippet);
+        new Notice("Copied Todoist Board block", 1500);
+      } catch {
+        new Notice("Could not copy block", 1500);
+      }
+    };
     const repoItem = nextList.createEl("li");
     repoItem.appendText("Filters: ");
     this.createExternalLink(repoItem, "GitHub", "https://github.com/propranolol11/todoist-board", "github");
@@ -141,13 +166,12 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
     this.renderPanelHeader(
       container,
       "Advanced",
-      "Tune logging and date handling for this vault.",
+      "",
     );
 
     const advancedCard = container.createDiv({ cls: "todoist-settings-card" });
     new Setting(advancedCard)
       .setName("Console logging")
-      .setDesc("Print debug output of Todoist Board to the developer console.")
       .addToggle((toggle) => {
         toggle
           .setValue(!!this.plugin.settings.enableLogs)
@@ -160,7 +184,6 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
 
     new Setting(advancedCard)
       .setName("Timezone mode")
-      .setDesc("Choose how timezone is determined for your tasks.")
       .addDropdown((dropdown) =>
         dropdown
           .addOption("auto", "Auto (use device timezone)")
@@ -176,7 +199,6 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
     if (pluginSettings.timezoneMode === "manual") {
       new Setting(advancedCard)
         .setName("Manual timezone")
-        .setDesc("Overrides system timezone if 'manual' mode is selected above")
         .addDropdown((dropdown) => {
           for (const timezone of COMMON_TIMEZONES) dropdown.addOption(timezone, timezone);
           dropdown.setValue(this.plugin.settings.manualTimezone);
@@ -405,12 +427,27 @@ export class TodoistBoardSettingTab extends PluginSettingTab {
       cls: "todoist-settings-card-desc",
     });
     this.createExternalLink(repoCard, "Open GitHub repo", "https://github.com/propranolol11/todoist-board", "external-link");
+
+    const bugCard = container.createDiv({ cls: "todoist-settings-card" });
+    this.renderHeading(bugCard, "Submit a bug", "todoist-settings-card-title");
+    bugCard.createEl("p", {
+      text: "Found something broken? Open a GitHub issue so it can be tracked.",
+      cls: "todoist-settings-card-desc",
+    });
+    this.createExternalLink(
+      bugCard,
+      "Open new issue",
+      "https://github.com/propranolol11/todoist-board/issues/new",
+      "bug",
+    );
   }
 
   private renderPanelHeader(container: HTMLElement, title: string, description: string) {
     const header = container.createDiv({ cls: "todoist-settings-panel-header" });
     this.renderHeading(header, title, "todoist-settings-panel-title");
-    header.createEl("p", { text: description, cls: "todoist-settings-panel-desc" });
+    if (description) {
+      header.createEl("p", { text: description, cls: "todoist-settings-panel-desc" });
+    }
   }
 
   private renderHeading(container: HTMLElement, title: string, titleClass: string) {

--- a/src/token-storage.ts
+++ b/src/token-storage.ts
@@ -1,0 +1,106 @@
+import type { TodoistBoardSettings } from "./types";
+
+export const TODOIST_API_TOKEN_SECRET_ID = "todoist-board-api-token";
+
+export interface SecretStorageLike {
+  getSecret(id: string): string | null;
+  setSecret(id: string, secret: string): void;
+  listSecrets?(): string[];
+}
+
+export interface AppWithSecretStorage {
+  secretStorage?: SecretStorageLike;
+}
+
+export interface TokenLoadResult {
+  token: string;
+  migrated: boolean;
+  storage: "secrets" | "plugin-data";
+  shouldRewriteSettings: boolean;
+}
+
+function normalizeToken(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .replace(/^Bearer\s+/i, "")
+    .replace(/^["']|["']$/g, "")
+    .trim();
+}
+
+export class TodoistTokenStorage {
+  private readonly secretStorage?: SecretStorageLike;
+  private readonly secretId: string;
+
+  constructor(app?: AppWithSecretStorage, secretId = TODOIST_API_TOKEN_SECRET_ID) {
+    this.secretStorage = app?.secretStorage;
+    this.secretId = secretId;
+  }
+
+  hasSecretStorage(): boolean {
+    return !!this.secretStorage;
+  }
+
+  loadToken(legacyToken: unknown): TokenLoadResult {
+    const settingsToken = normalizeToken(legacyToken);
+    const secretToken = this.readSecret();
+
+    if (secretToken) {
+      return {
+        token: secretToken,
+        migrated: false,
+        storage: "secrets",
+        shouldRewriteSettings: !!settingsToken,
+      };
+    }
+
+    if (settingsToken && this.writeSecret(settingsToken)) {
+      return {
+        token: settingsToken,
+        migrated: true,
+        storage: "secrets",
+        shouldRewriteSettings: true,
+      };
+    }
+
+    return {
+      token: settingsToken,
+      migrated: false,
+      storage: "plugin-data",
+      shouldRewriteSettings: false,
+    };
+  }
+
+  prepareSettingsForSave<T extends TodoistBoardSettings>(settings: T): T {
+    const token = normalizeToken(settings.apiKey);
+    const next = { ...settings, apiKey: token };
+
+    if (!this.hasSecretStorage()) {
+      return next;
+    }
+
+    if (this.writeSecret(token)) {
+      return { ...next, apiKey: "" };
+    }
+
+    return next;
+  }
+
+  private readSecret(): string {
+    if (!this.secretStorage) return "";
+    try {
+      return normalizeToken(this.secretStorage.getSecret(this.secretId));
+    } catch {
+      return "";
+    }
+  }
+
+  private writeSecret(token: string): boolean {
+    if (!this.secretStorage) return false;
+    try {
+      this.secretStorage.setSecret(this.secretId, token);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -4122,8 +4122,15 @@ body.tb-scroll-lock {
 }
 
 .todoist-board-settings-tab .todoist-settings-card .setting-item {
+  background: transparent;
   border-top: 0;
+  box-shadow: none;
   padding: 0;
+}
+
+.todoist-board-settings-tab .todoist-settings-card .setting-item-control {
+  background: transparent;
+  box-shadow: none;
 }
 
 .todoist-board-settings-tab .todoist-settings-card .setting-item-info {
@@ -4167,6 +4174,33 @@ body.tb-scroll-lock {
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 10px;
+}
+
+.todoist-board-settings-tab .todoist-settings-security-note {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.35;
+  margin-top: 10px;
+}
+
+.todoist-board-settings-tab .todoist-settings-security-note summary {
+  cursor: pointer;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.todoist-board-settings-tab .todoist-settings-security-note p {
+  margin: 6px 0 0;
+  max-width: 58ch;
+}
+
+.todoist-board-settings-tab .todoist-settings-security-note a {
+  color: var(--text-accent);
+  text-decoration: none;
+}
+
+.todoist-board-settings-tab .todoist-settings-security-note a:hover {
+  text-decoration: underline;
 }
 
 .todoist-board-settings-tab .todoist-settings-link,
@@ -4220,6 +4254,53 @@ body.tb-scroll-lock {
   font-size: 0.78rem;
   padding: 2px 5px;
   white-space: normal;
+}
+
+.todoist-board-settings-tab .todoist-settings-copy-code {
+  margin-top: 6px;
+  position: relative;
+}
+
+.todoist-board-settings-tab .todoist-settings-copy-code .todoist-settings-code-example {
+  background: var(--code-background, var(--background-secondary));
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  box-shadow: none;
+  color: var(--code-normal, var(--text-normal));
+  margin: 0;
+  padding-right: 72px;
+}
+
+.todoist-board-settings-tab .todoist-settings-copy-code .todoist-settings-code-example code {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  display: block;
+  font-size: inherit;
+  padding: 0;
+  white-space: pre;
+}
+
+.todoist-board-settings-tab .todoist-settings-copy-code-button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.76rem;
+  font-weight: 600;
+  height: 26px;
+  padding: 0 8px;
+  position: absolute;
+  right: 6px;
+  top: 6px;
+}
+
+.todoist-board-settings-tab .todoist-settings-copy-code-button:hover {
+  background: var(--background-modifier-hover);
+  border-color: var(--background-modifier-border);
+  color: var(--text-normal);
 }
 
 .todoist-board-settings-tab .todoist-settings-next-list .todoist-settings-link {

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -9,6 +9,7 @@ import { sortTasksLikeTodoist } from "../src/sort.ts";
 import { TodoistBoardStorage, writeJSON } from "../src/storage.ts";
 import { TaskStore } from "../src/task-store.ts";
 import { getSubtasksForParent, TaskHierarchy } from "../src/task-hierarchy.ts";
+import { TODOIST_API_TOKEN_SECRET_ID, TodoistTokenStorage, type SecretStorageLike } from "../src/token-storage.ts";
 import {
   isTodoistRequestError,
   normalizeTask,
@@ -146,6 +147,61 @@ test("task store hydrates legacy cache and writes an authoritative snapshot", ()
   assert.deepEqual(store.getViewTasks("today"), []);
   assert.deepEqual(clearedSnapshot.filterIndex.today, undefined);
   assert.deepEqual(clearedSnapshot.taskCache.today, undefined);
+});
+
+function makeSecretStorage(): SecretStorageLike & { values: Map<string, string> } {
+  const values = new Map<string, string>();
+  return {
+    values,
+    getSecret: (id) => values.get(id) ?? null,
+    setSecret: (id, secret) => {
+      values.set(id, secret);
+    },
+    listSecrets: () => Array.from(values.keys()),
+  };
+}
+
+test("token storage migrates plugin-data tokens into Obsidian secrets and redacts saved settings", () => {
+  const secretStorage = makeSecretStorage();
+  const tokenStorage = new TodoistTokenStorage({ secretStorage });
+
+  const loaded = tokenStorage.loadToken('Bearer "legacy-token"');
+
+  assert.equal(loaded.token, "legacy-token");
+  assert.equal(loaded.migrated, true);
+  assert.equal(loaded.storage, "secrets");
+  assert.equal(loaded.shouldRewriteSettings, true);
+  assert.equal(secretStorage.values.get(TODOIST_API_TOKEN_SECRET_ID), "legacy-token");
+
+  const persisted = tokenStorage.prepareSettingsForSave({ ...settings, apiKey: "legacy-token" });
+  assert.equal(persisted.apiKey, "");
+  assert.equal(secretStorage.values.get(TODOIST_API_TOKEN_SECRET_ID), "legacy-token");
+});
+
+test("token storage prefers existing Obsidian secret over stale plugin-data token", () => {
+  const secretStorage = makeSecretStorage();
+  secretStorage.setSecret(TODOIST_API_TOKEN_SECRET_ID, "secret-token");
+  const tokenStorage = new TodoistTokenStorage({ secretStorage });
+
+  const loaded = tokenStorage.loadToken("old-token");
+
+  assert.equal(loaded.token, "secret-token");
+  assert.equal(loaded.migrated, false);
+  assert.equal(loaded.storage, "secrets");
+  assert.equal(loaded.shouldRewriteSettings, true);
+});
+
+test("token storage preserves plugin-data fallback when Obsidian secrets are unavailable", () => {
+  const tokenStorage = new TodoistTokenStorage();
+
+  const loaded = tokenStorage.loadToken("legacy-token");
+  const persisted = tokenStorage.prepareSettingsForSave({ ...settings, apiKey: "legacy-token" });
+
+  assert.equal(loaded.token, "legacy-token");
+  assert.equal(loaded.migrated, false);
+  assert.equal(loaded.storage, "plugin-data");
+  assert.equal(loaded.shouldRewriteSettings, false);
+  assert.equal(persisted.apiKey, "legacy-token");
 });
 
 test("todoist normalization and payload helpers preserve API field mappings", () => {


### PR DESCRIPTION
## Summary

- Bump Todoist Board from `2.0.9` to `2.1.0` in package and Obsidian manifest metadata.
- Store Todoist API tokens in Obsidian Secret Storage when available, with automatic migration from legacy plugin-data tokens.
- Preserve plugin-data token fallback for older Obsidian versions.
- Update settings UI/README copy and add release-readiness tests for migration, stale data handling, and fallback behavior.

## Validation

- `npm run verify`

## Release note

After this PR lands, create/publish the `2.1.0` GitHub release from the merged `main` commit so the release provenance workflow can build and attach `main.js`, `manifest.json`, and `styles.css`.