### PR TITLE
[codex] Update release workflow actions

### DIFF
--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -30,12 +30,12 @@ jobs:
           fi
 
       - name: Checkout release source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
         with:
           ref: ${{ steps.release.outputs.tag }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "22"
           cache: npm
@@ -56,7 +56,7 @@ jobs:
           test "$manifest_version" = "${{ steps.release.outputs.tag }}"
 
       - name: Attest release assets
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-path: |
             main.js


### PR DESCRIPTION
## Summary

- Update release workflow actions to newer Node 24-compatible major versions:
  - `actions/checkout@v6.0.3`
  - `actions/setup-node@v6.4.0`
  - `actions/attest-build-provenance@v4.1.0`
- Keep the plugin build runtime at Node `22`; this only updates the GitHub Actions runtime packages that triggered the Node.js 20 deprecation warning.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-provenance.yml")'`
- `git diff --check`

## Notes

This is CI maintenance only and does not change the already published `2.1.0` plugin release.